### PR TITLE
First implementations of 'MetaProperty'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,18 @@
     <maven>3.0.4</maven>
   </prerequisites>
   <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>${mockito-all.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <!-- ==================================================================== -->
@@ -318,5 +330,8 @@
     <!-- Other properties -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <!-- Dependency version numbers -->
+    <junit.version>4.12</junit.version>
+    <mockito-all.version>1.10.8</mockito-all.version>
   </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -280,9 +280,9 @@
   </prerequisites>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>${testng.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -331,7 +331,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- Dependency version numbers -->
-    <junit.version>4.12</junit.version>
+    <testng.version>6.8.8</testng.version>
     <mockito-all.version>1.10.8</mockito-all.version>
   </properties>
 </project>

--- a/src/main/java/org/joda/pa/AbstractMetaProperty.java
+++ b/src/main/java/org/joda/pa/AbstractMetaProperty.java
@@ -120,8 +120,15 @@ abstract class AbstractMetaProperty<P> implements MetaProperty<P> {
     }
 
     private P ensureValueHasCorrectType(Object value) {
-        // TODO do we want a customized exception message?
-        return propertyTypeToken.cast(value);
+        try {
+            return propertyTypeToken.cast(value);
+        } catch (ClassCastException ex) {
+            String message = "The specified value " + value + " is of type '"
+                    + value.getClass() + "' which is not assignment compatible"
+                    + " with this meta-property's content type '"
+                    + propertyTypeToken + "'.";
+            throw new ClassCastException(message);
+        }
     }
 
     /**

--- a/src/main/java/org/joda/pa/AbstractMetaProperty.java
+++ b/src/main/java/org/joda/pa/AbstractMetaProperty.java
@@ -152,16 +152,16 @@ abstract class AbstractMetaProperty<P> implements MetaProperty<P> {
         if (obj == null) {
             return false;
         }
-        if (!(obj instanceof AbstractMetaProperty)) {
+        if (!(obj instanceof MetaProperty)) {
             return false;
         }
 
         @SuppressWarnings("rawtypes")
-        AbstractMetaProperty other = (AbstractMetaProperty) obj;
-        if (!Objects.equals(metaBean, other.metaBean)) {
+        MetaProperty other = (MetaProperty) obj;
+        if (!Objects.equals(declaringType(), other.declaringType())) {
             return false;
         }
-        if (!Objects.equals(name, other.name)) {
+        if (!Objects.equals(name(), other.name())) {
             return false;
         }
 

--- a/src/main/java/org/joda/pa/AbstractMetaProperty.java
+++ b/src/main/java/org/joda/pa/AbstractMetaProperty.java
@@ -1,0 +1,165 @@
+package org.joda.pa;
+
+import java.util.Objects;
+
+/**
+ * Abstract superclass to {@link MetaProperty} implementations.
+ * 
+ * @param <P> the type of the property content
+ */
+abstract class AbstractMetaProperty<P> implements MetaProperty<P> {
+
+    private final MetaBean metaBean;
+    private final String name;
+    private final Class<P> propertyTypeToken;
+    private final boolean buildable;
+    private final boolean mutable;
+    private final boolean derived;
+
+    /**
+     * This constructor does not check these arguments.
+     * It relies on the calling builder to do so.
+     */
+    protected AbstractMetaProperty(MetaBean metaBean, String name,
+            Class<P> propertyTypeToken, boolean buildable, boolean mutable,
+            boolean derived) {
+
+        this.metaBean = metaBean;
+        this.name = name;
+        this.propertyTypeToken = propertyTypeToken;
+        this.buildable = buildable;
+        this.mutable = mutable;
+        this.derived = derived;
+    }
+
+    // (partial) implementation of 'MetaProperty' -----------------------------
+
+    @Override
+    public final MetaBean metaBean() {
+        return metaBean;
+    }
+
+    @Override
+    public final String name() {
+        return name;
+    }
+
+    @Override
+    public final Class<P> propertyType() {
+        return propertyTypeToken;
+    }
+
+    @Override
+    public final boolean isBuildable() {
+        return buildable;
+    }
+
+    @Override
+    public final boolean isDerived() {
+        return derived;
+    }
+
+    @Override
+    public final boolean isMutable() {
+        return mutable;
+    }
+
+    @Override
+    public final P get(Object bean) {
+        Objects.requireNonNull(bean, "The argument 'bean' must not be null.");
+
+        ensurePropertyCanBeRead();
+        ensureBeanHasCorrectType(bean);
+        return getFromBean(bean);
+    }
+
+    private void ensurePropertyCanBeRead() {
+        // TODO check write-only, see Ticket #3; also add tests
+    }
+
+    private void ensureBeanHasCorrectType(Object bean) {
+        boolean beanHasIncorrectType = !declaringClass().isInstance(bean);
+        if (beanHasIncorrectType) {
+            String message = "The specified bean " + bean + " is of type '"
+                    + bean.getClass() + "' which is not assignment compatible"
+                    + " with this meta-property's declaring type '"
+                    + declaringClass() + "'.";
+            throw new ClassCastException(message);
+        }
+    }
+
+    /**
+     * Implemented by subclasses to actually get the value from the bean.
+     * 
+     * @param bean  the bean to query, is not null and of the correct type as returned by {@link #declaringClass()}
+     * @return the value of the property on the specified bean, may be null
+     */
+    protected abstract P getFromBean(Object bean);
+
+    @Override
+    public final void set(Object bean, Object value) {
+        Objects.requireNonNull(bean, "The argument 'bean' must not be null.");
+
+        ensurePropertyCanBeWritten();
+        ensureBeanHasCorrectType(bean);
+        P typedValue = ensureValueHasCorrectType(value);
+        setToBean(bean, typedValue);
+    }
+
+    private void ensurePropertyCanBeWritten() {
+        if (!mutable) {
+            String message = "This meta-property is read-only.";
+            throw new UnsupportedOperationException(message);
+        }
+    }
+
+    private P ensureValueHasCorrectType(Object value) {
+        // TODO do we want a customized exception message?
+        return propertyTypeToken.cast(value);
+    }
+
+    /**
+     * Implemented by subclasses to actually set the value to the bean.
+     * 
+     * @param bean  the bean to modify, is not null and of the correct type as returned by {@link #declaringClass()}
+     * @param value  the value to set to the bean, may be null
+     */
+    protected abstract void setToBean(Object bean, P value);
+
+    // 'Object' methods -------------------------------------------------------
+
+    @Override
+    public final int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result
+                + ((metaBean == null) ? 0 : metaBean.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof AbstractMetaProperty)) {
+            return false;
+        }
+
+        @SuppressWarnings("rawtypes")
+        AbstractMetaProperty other = (AbstractMetaProperty) obj;
+        if (!Objects.equals(metaBean, other.metaBean)) {
+            return false;
+        }
+        if (!Objects.equals(name, other.name)) {
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/src/main/java/org/joda/pa/AbstractMetaProperty.java
+++ b/src/main/java/org/joda/pa/AbstractMetaProperty.java
@@ -71,12 +71,12 @@ abstract class AbstractMetaProperty<P> implements MetaProperty<P> {
     public final P get(Object bean) {
         Objects.requireNonNull(bean, "The argument 'bean' must not be null.");
 
-        ensurePropertyCanBeRead();
+        ensurePropertyIsReadable();
         ensureBeanHasCorrectType(bean);
         return getFromBean(bean);
     }
 
-    private void ensurePropertyCanBeRead() {
+    private void ensurePropertyIsReadable() {
         if (!readable) {
             String message = "This meta-property is write-only.";
             throw new UnsupportedOperationException(message);

--- a/src/main/java/org/joda/pa/AbstractMetaProperty.java
+++ b/src/main/java/org/joda/pa/AbstractMetaProperty.java
@@ -12,22 +12,25 @@ abstract class AbstractMetaProperty<P> implements MetaProperty<P> {
     private final MetaBean metaBean;
     private final String name;
     private final Class<P> propertyTypeToken;
-    private final boolean buildable;
-    private final boolean mutable;
     private final boolean derived;
+    private final boolean buildable;
+    private final boolean readable;
+    private final boolean mutable;
 
     /**
      * This constructor does not check these arguments.
      * It relies on the calling builder to do so.
      */
-    protected AbstractMetaProperty(MetaBean metaBean, String name,
-            Class<P> propertyTypeToken, boolean buildable, boolean mutable,
-            boolean derived) {
+    protected AbstractMetaProperty(
+            MetaBean metaBean, String name, Class<P> propertyTypeToken,
+            boolean derived, boolean buildable,
+            boolean readable, boolean mutable) {
 
         this.metaBean = metaBean;
         this.name = name;
         this.propertyTypeToken = propertyTypeToken;
         this.buildable = buildable;
+        this.readable = readable;
         this.mutable = mutable;
         this.derived = derived;
     }
@@ -74,7 +77,10 @@ abstract class AbstractMetaProperty<P> implements MetaProperty<P> {
     }
 
     private void ensurePropertyCanBeRead() {
-        // TODO check write-only, see Ticket #3; also add tests
+        if (!readable) {
+            String message = "This meta-property is write-only.";
+            throw new UnsupportedOperationException(message);
+        }
     }
 
     private void ensureBeanHasCorrectType(Object bean) {

--- a/src/main/java/org/joda/pa/AbstractMetaProperty.java
+++ b/src/main/java/org/joda/pa/AbstractMetaProperty.java
@@ -84,12 +84,12 @@ abstract class AbstractMetaProperty<P> implements MetaProperty<P> {
     }
 
     private void ensureBeanHasCorrectType(Object bean) {
-        boolean beanHasIncorrectType = !declaringClass().isInstance(bean);
+        boolean beanHasIncorrectType = !declaringType().isInstance(bean);
         if (beanHasIncorrectType) {
             String message = "The specified bean " + bean + " is of type '"
                     + bean.getClass() + "' which is not assignment compatible"
                     + " with this meta-property's declaring type '"
-                    + declaringClass() + "'.";
+                    + declaringType() + "'.";
             throw new ClassCastException(message);
         }
     }

--- a/src/main/java/org/joda/pa/FieldMetaProperty.java
+++ b/src/main/java/org/joda/pa/FieldMetaProperty.java
@@ -55,6 +55,11 @@ class FieldMetaProperty<P> extends AbstractMetaProperty<P> {
         try {
             Object untypedValue = backingField.get(bean);
             return propertyType().cast(untypedValue);
+        } catch (IllegalAccessException ex) {
+            // because the backing field is made accessible during construction,
+            // this exception should never occur
+            String message = "The field backing this meta-property is not accessible.";
+            throw new RuntimeException(message, ex);
         } catch (IllegalArgumentException ex) {
             // this exception can only occur if the bean does not have the correct type;
             // this was already checked by the superclass so this should not happen
@@ -62,11 +67,6 @@ class FieldMetaProperty<P> extends AbstractMetaProperty<P> {
                     + "does not declare the field backing this meta-property: "
                     + ex.getMessage();
             throw new ClassCastException(message);
-        } catch (IllegalAccessException ex) {
-            // because the backing field is made accessible during construction,
-            // this exception should never occur
-            String message = "The field backing this meta-property is not accessible.";
-            throw new RuntimeException(message, ex);
         }
     }
 
@@ -74,6 +74,11 @@ class FieldMetaProperty<P> extends AbstractMetaProperty<P> {
     protected void setToBean(Object bean, P value) {
         try {
             backingField.set(bean, value);
+        } catch (IllegalAccessException ex) {
+            // because the backing field is made accessible during construction,
+            // this exception should never occur
+            String message = "The field backing this meta-property is not accessible.";
+            throw new RuntimeException(message, ex);
         } catch (IllegalArgumentException ex) {
             // this exception can occur for two reasons:
             //  - if the bean does not have the correct type;
@@ -86,11 +91,6 @@ class FieldMetaProperty<P> extends AbstractMetaProperty<P> {
                     + "because the types do not match: "
                     + ex.getMessage();
             throw new ClassCastException(message);
-        } catch (IllegalAccessException ex) {
-            // because the backing field is made accessible during construction,
-            // this exception should never occur
-            String message = "The field backing this meta-property is not accessible.";
-            throw new RuntimeException(message, ex);
         }
     }
 }

--- a/src/main/java/org/joda/pa/FieldMetaProperty.java
+++ b/src/main/java/org/joda/pa/FieldMetaProperty.java
@@ -20,11 +20,12 @@ class FieldMetaProperty<P> extends AbstractMetaProperty<P> {
      */
     FieldMetaProperty(
             MetaBean metaBean, String name, Class<P> propertyTypeToken,
-            boolean buildable, boolean derived, boolean mutable,
+            boolean derived, boolean buildable,
+            boolean readable, boolean mutable,
             Field backingField) {
 
         super(metaBean, name, propertyTypeToken,
-                buildable, mutable, derived);
+                derived, buildable, readable, mutable);
 
         this.backingField = backingField;
         makeAccessible(backingField);

--- a/src/main/java/org/joda/pa/FieldMetaProperty.java
+++ b/src/main/java/org/joda/pa/FieldMetaProperty.java
@@ -41,7 +41,7 @@ class FieldMetaProperty<P> extends AbstractMetaProperty<P> {
     }
 
     @Override
-    public <A extends Annotation> Stream<A> annotation(Class<A> annotationType) {
+    public <A extends Annotation> Stream<A> annotations(Class<A> annotationType) {
         A annotation = backingField.getAnnotation(annotationType);
         if (annotation == null) {
             return Stream.empty();

--- a/src/main/java/org/joda/pa/FieldMetaProperty.java
+++ b/src/main/java/org/joda/pa/FieldMetaProperty.java
@@ -1,0 +1,95 @@
+package org.joda.pa;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.stream.Stream;
+
+/**
+ * A {@link MetaProperty} which reflects on a {@link Field}
+ * (provided during construction) to get/set values and access annotations.
+ * 
+ * @param <P> the type of the property content
+ */
+class FieldMetaProperty<P> extends AbstractMetaProperty<P> {
+
+    private final Field backingField;
+
+    /**
+     * This constructor does not check these arguments.
+     * It relies on the calling builder to do so.
+     */
+    FieldMetaProperty(
+            MetaBean metaBean, String name, Class<P> propertyTypeToken,
+            boolean buildable, boolean derived, boolean mutable,
+            Field backingField) {
+
+        super(metaBean, name, propertyTypeToken,
+                buildable, mutable, derived);
+
+        this.backingField = backingField;
+        makeAccessible(backingField);
+    }
+
+    private static void makeAccessible(Field backingField) {
+        backingField.setAccessible(true);
+    }
+
+    @Override
+    public Stream<Annotation> annotations() {
+        return Stream.of(backingField.getAnnotations());
+    }
+
+    @Override
+    public <A extends Annotation> Stream<A> annotation(Class<A> annotationType) {
+        A annotation = backingField.getAnnotation(annotationType);
+        if (annotation == null) {
+            return Stream.empty();
+        } else {
+            return Stream.of(annotation);
+        }
+    }
+
+    @Override
+    protected P getFromBean(Object bean) {
+        try {
+            Object untypedValue = backingField.get(bean);
+            return propertyType().cast(untypedValue);
+        } catch (IllegalArgumentException ex) {
+            // this exception can only occur if the bean does not have the correct type;
+            // this was already checked by the superclass so this should not happen
+            String message = "The specified bean "
+                    + "does not declare the field backing this meta-property: "
+                    + ex.getMessage();
+            throw new ClassCastException(message);
+        } catch (IllegalAccessException ex) {
+            // because the backing field is made accessible during construction,
+            // this exception should never occur
+            String message = "The field backing this meta-property is not accessible.";
+            throw new RuntimeException(message, ex);
+        }
+    }
+
+    @Override
+    protected void setToBean(Object bean, P value) {
+        try {
+            backingField.set(bean, value);
+        } catch (IllegalArgumentException ex) {
+            // this exception can occur for two reasons:
+            //  - if the bean does not have the correct type;
+            //      (was already checked by the superclass so this should not happen)
+            //  - the value's type does not match the field's type
+            //      (was checked by the builder during construction so this should not happen)
+            String message = "The specified bean "
+                    + "does not declare the field backing this meta-property "
+                    + "or the value is not assignable to the backing field "
+                    + "because the types do not match: "
+                    + ex.getMessage();
+            throw new ClassCastException(message);
+        } catch (IllegalAccessException ex) {
+            // because the backing field is made accessible during construction,
+            // this exception should never occur
+            String message = "The field backing this meta-property is not accessible.";
+            throw new RuntimeException(message, ex);
+        }
+    }
+}

--- a/src/main/java/org/joda/pa/FunctionalMetaProperty.java
+++ b/src/main/java/org/joda/pa/FunctionalMetaProperty.java
@@ -1,0 +1,58 @@
+package org.joda.pa;
+
+import java.lang.annotation.Annotation;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * A {@link MetaProperty} which delegates calls to functional interfaces
+ * (provided during construction) to get/set values and access annotations.
+ * 
+ * @param <P> the type of the property content
+ */
+class FunctionalMetaProperty<P> extends AbstractMetaProperty<P> {
+
+    private final Function<Object, P> getValue;
+    private final BiConsumer<Object, P> setValue;
+    private final Supplier<Stream<Annotation>> getAnnotations;
+
+    /**
+     * This constructor does not check these arguments.
+     * It relies on the calling builder to do so.
+     */
+    FunctionalMetaProperty(
+            MetaBean metaBean, String name, Class<P> propertyTypeToken,
+            boolean buildable, boolean derived,
+            Function<Object, P> getValue, BiConsumer<Object, P> setValue,
+            Supplier<Stream<Annotation>> getAnnotations) {
+
+        super(metaBean, name, propertyTypeToken,
+                buildable, isMutable(setValue), derived);
+
+        this.getValue = getValue;
+        this.setValue = setValue;
+        this.getAnnotations = getAnnotations;
+    }
+
+    private static boolean isMutable(BiConsumer<?, ?> setValue) {
+        return setValue != null;
+    }
+
+    @Override
+    public Stream<Annotation> annotations() {
+        return getAnnotations.get();
+    }
+
+    @Override
+    protected P getFromBean(Object bean) {
+        return getValue.apply(bean);
+    }
+
+    @Override
+    protected void setToBean(Object bean, P value) {
+        setValue.accept(bean, value);
+    }
+
+}

--- a/src/main/java/org/joda/pa/FunctionalMetaProperty.java
+++ b/src/main/java/org/joda/pa/FunctionalMetaProperty.java
@@ -24,16 +24,20 @@ class FunctionalMetaProperty<P> extends AbstractMetaProperty<P> {
      */
     FunctionalMetaProperty(
             MetaBean metaBean, String name, Class<P> propertyTypeToken,
-            boolean buildable, boolean derived,
+            boolean derived, boolean buildable,
             Function<Object, P> getValue, BiConsumer<Object, P> setValue,
             Supplier<Stream<Annotation>> getAnnotations) {
 
         super(metaBean, name, propertyTypeToken,
-                buildable, isMutable(setValue), derived);
+                derived, buildable, isReadable(getValue), isMutable(setValue));
 
         this.getValue = getValue;
         this.setValue = setValue;
         this.getAnnotations = getAnnotations;
+    }
+
+    private static boolean isReadable(Function<?, ?> getValue) {
+        return getValue != null;
     }
 
     private static boolean isMutable(BiConsumer<?, ?> setValue) {

--- a/src/main/java/org/joda/pa/MetaProperty.java
+++ b/src/main/java/org/joda/pa/MetaProperty.java
@@ -214,7 +214,8 @@ public interface MetaProperty<P> {
      * Checks if this meta-property equals another.
      * <p>
      * Two properties are equal if they provide access to the same value.
-     * This is typically accomplished by comparing the property name and declaring class.
+     * This is typically accomplished by comparing the {@link #name() property name}
+     * and the {@link #declaringType() bean type}.
      * The value of the property must not be used.
      * 
      * @param obj  the other meta-property, null returns false

--- a/src/main/java/org/joda/pa/MethodMetaProperty.java
+++ b/src/main/java/org/joda/pa/MethodMetaProperty.java
@@ -1,0 +1,124 @@
+package org.joda.pa;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.stream.Stream;
+
+/**
+ * A {@link MetaProperty} which reflects on {@link Method}s
+ * (provided during construction) to get/set values and access annotations.
+ * 
+ * @param <P> the type of the property content
+ */
+class MethodMetaProperty<P> extends AbstractMetaProperty<P> {
+
+    private final Method getValue;
+    private final Method setValue;
+
+    protected MethodMetaProperty(
+            MetaBean metaBean, String name, Class<P> propertyTypeToken,
+            boolean buildable, boolean derived,
+            Method getValue, Method setValue) {
+
+        super(metaBean, name, propertyTypeToken,
+                derived, buildable, isReadable(getValue), isMutable(setValue));
+
+        this.getValue = getValue;
+        this.setValue = setValue;
+        makeAccessible(getValue, setValue);
+    }
+
+    private static boolean isReadable(Method getValue) {
+        return getValue != null;
+    }
+
+    private static boolean isMutable(Method setValue) {
+        return setValue != null;
+    }
+
+    private static void makeAccessible(Method getValue, Method setValue) {
+        if (getValue != null) {
+            getValue.setAccessible(true);
+        }
+        if (setValue != null) {
+            setValue.setAccessible(true);
+        }
+    }
+
+    @Override
+    public Stream<Annotation> annotations() {
+        // TODO (nipa@codefx.org)
+        return null;
+    }
+
+    @Override
+    protected P getFromBean(Object bean) {
+        Object untypedValue = invoke(bean, getValue, MethodPurpose.GET);
+        return propertyType().cast(untypedValue);
+    }
+
+    @Override
+    protected void setToBean(Object bean, P value) {
+        invoke(bean, setValue, MethodPurpose.SET, value);
+    }
+
+    private static Object invoke(
+            Object bean, Method method, MethodPurpose purpose, Object... args) {
+
+        try {
+            return method.invoke(bean, args);
+        } catch (IllegalAccessException ex) {
+            // because the backing field is made accessible during construction,
+            // this exception should never occur
+            String message = "The method used by this meta-property to "
+                    + purpose.formated()
+                    + " values is not accessible.";
+            throw new RuntimeException(message, ex);
+        } catch (IllegalArgumentException ex) {
+            // this exception can only occur if the bean does not have the correct type;
+            // this was already checked by the superclass so this should not happen
+            String message = "The specified bean does not declare the method "
+                    + "used by this meta-property to "
+                    + purpose.formated()
+                    + " values: "
+                    + ex.getMessage();
+            throw new ClassCastException(message);
+        } catch (InvocationTargetException ex) {
+            // the caught exception contains the actual exception thrown by the
+            // method invocation; rethrow that exception if possible (i.e. it
+            // is unchecked) or throw a new RuntimeException
+            Throwable thrownByMethod = ex.getCause();
+            if (thrownByMethod instanceof RuntimeException) {
+                throw (RuntimeException) thrownByMethod;
+            } else {
+                String message = "Invocating the method used by this meta-property to "
+                        + purpose.formated()
+                        + " values caused an exception. "
+                        + "That exception is the cause for this exception "
+                        + "(i.e. can be accessed by calling 'getCause()').";
+                throw new RuntimeException(message, thrownByMethod);
+            }
+        }
+    }
+
+    /**
+     * Indicates which purpose the method passed to invoke has.
+     */
+    private static enum MethodPurpose {
+        GET,
+        SET;
+
+        public String formated() {
+            switch (this) {
+                case GET:
+                    return "get";
+                case SET:
+                    return "set";
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/joda/pa/MethodMetaProperty.java
+++ b/src/main/java/org/joda/pa/MethodMetaProperty.java
@@ -48,8 +48,20 @@ class MethodMetaProperty<P> extends AbstractMetaProperty<P> {
 
     @Override
     public Stream<Annotation> annotations() {
-        // TODO (nipa@codefx.org)
-        return null;
+        Stream<Annotation> annotationsOnGetValue =
+                Stream.of(getValue.getAnnotations());
+        Stream<Annotation> annotationsOnSetValue =
+                Stream.of(setValue.getAnnotations());
+        return Stream.concat(annotationsOnGetValue, annotationsOnSetValue);
+    }
+
+    @Override
+    public <A extends Annotation> Stream<A> annotations(Class<A> annotationType) {
+        A annotationOnGetValue = getValue.getAnnotation(annotationType);
+        A annotationOnSetValue = setValue.getAnnotation(annotationType);
+        return Stream
+                .of(annotationOnGetValue, annotationOnSetValue)
+                .filter(element -> element != null);
     }
 
     @Override

--- a/src/main/java/org/joda/pa/MethodMetaProperty.java
+++ b/src/main/java/org/joda/pa/MethodMetaProperty.java
@@ -18,7 +18,7 @@ class MethodMetaProperty<P> extends AbstractMetaProperty<P> {
 
     protected MethodMetaProperty(
             MetaBean metaBean, String name, Class<P> propertyTypeToken,
-            boolean buildable, boolean derived,
+            boolean derived, boolean buildable,
             Method getValue, Method setValue) {
 
         super(metaBean, name, propertyTypeToken,

--- a/src/test/java/org/joda/pa/AbstractFieldNameBasedMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractFieldNameBasedMetaPropertyTest.java
@@ -59,6 +59,22 @@ abstract class AbstractFieldNameBasedMetaPropertyTest extends
     }
 
     @Override
+    protected final MetaProperty<Object> createDerivedObjectMetaProperty()
+            throws Exception {
+        return createMetaProperty(
+                null, "object", Object.class,
+                true, true, true, false, "object");
+    }
+
+    @Override
+    protected final MetaProperty<Object> createNotBuildableObjectMetaProperty()
+            throws Exception {
+        return createMetaProperty(
+                null, "object", Object.class,
+                false, false, true, false, "object");
+    }
+
+    @Override
     protected final MetaProperty<String> createStringMetaProperty()
             throws Exception {
         return createMetaProperty(null, String.class, "string");

--- a/src/test/java/org/joda/pa/AbstractFieldNameBasedMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractFieldNameBasedMetaPropertyTest.java
@@ -1,0 +1,103 @@
+package org.joda.pa;
+
+import java.util.List;
+
+/**
+ * Abstract superclass to tests of {@link MetaProperty} implementations, which
+ * use reflection to access values.
+ * <p>
+ * This is just a convenience superclass for {@link FieldMetaPropertyTest} and
+ * {@link MethodMetaPropertyTest} because both only differ in how exactly they
+ * reflect on the field name. Either by directly accessing the field or by
+ * deducing the beans getter/setter names for the field and reflecting on those
+ * methods. 
+ */
+abstract class AbstractFieldNameBasedMetaPropertyTest extends
+        AbstractMetaPropertyTest {
+
+    @Override
+    protected final TestBean createBean() {
+        return new FieldBackedTestBean();
+    }
+
+    @Override
+    protected final MetaProperty<Object> createObjectMetaProperty()
+            throws Exception {
+        return createMetaProperty(null, Object.class, "object");
+    }
+
+    @Override
+    protected final MetaProperty<Object> createObjectMetaPropertyWithMetaBean(
+            MetaBean metaBean)
+            throws Exception {
+        return createMetaProperty(metaBean, Object.class, "object");
+    }
+
+    @Override
+    protected final MetaProperty<Object> createObjectMetaPropertyWithName(
+            String name)
+            throws Exception {
+        return createMetaProperty(
+                null, name, Object.class,
+                false, true, true, true, "object");
+    }
+
+    @Override
+    protected final MetaProperty<Object> createReadOnlyObjectMetaProperty()
+            throws Exception {
+        return createMetaProperty(
+                null, "object", Object.class,
+                false, true, true, false, "object");
+    }
+
+    @Override
+    protected final MetaProperty<Object> createWriteOnlyObjectMetaProperty()
+            throws Exception {
+        return createMetaProperty(
+                null, "object", Object.class,
+                false, true, false, true, "object");
+    }
+
+    @Override
+    protected final MetaProperty<String> createStringMetaProperty()
+            throws Exception {
+        return createMetaProperty(null, String.class, "string");
+    }
+
+    @Override
+    protected final MetaProperty<Integer> createPrimitiveIntegerMetaProperty()
+            throws Exception {
+        return createMetaProperty(null, int.class, "primitiveInteger");
+    }
+
+    @Override
+    protected final MetaProperty<Integer> createIntegerMetaProperty()
+            throws Exception {
+        return createMetaProperty(null, Integer.class, "integer");
+    }
+
+    @Override
+    protected final MetaProperty<List<Double>> createDoubleListMetaProperty()
+            throws Exception {
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        // TODO is there a nicer way to do this?
+        Class<List<Double>> typeToken = ((Class) List.class);
+        return createMetaProperty(null, typeToken, "doubleList");
+    }
+
+    private <P> MetaProperty<P> createMetaProperty(
+            MetaBean metaBean, Class<P> typeToken, String fieldName)
+            throws Exception {
+
+        return createMetaProperty(
+                metaBean, fieldName, typeToken, false, true, true, true,
+                fieldName);
+    }
+
+    protected abstract <P> MetaProperty<P> createMetaProperty(
+            MetaBean metaBean, String name, Class<P> typeToken,
+            boolean derived, boolean buildable,
+            boolean readable, boolean mutable,
+            String fieldName)
+            throws Exception;
+}

--- a/src/test/java/org/joda/pa/AbstractFieldNameBasedMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractFieldNameBasedMetaPropertyTest.java
@@ -96,7 +96,6 @@ abstract class AbstractFieldNameBasedMetaPropertyTest extends
     protected final MetaProperty<List<Double>> createDoubleListMetaProperty()
             throws Exception {
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        // TODO is there a nicer way to do this?
         Class<List<Double>> typeToken = ((Class) List.class);
         return createMetaProperty(null, typeToken, "doubleList");
     }

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -1,0 +1,259 @@
+package org.joda.pa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.joda.pa.TestBean.AnyAnnotation;
+import org.junit.Test;
+
+/**
+ * Abstract superclass to tests of {@link MetaProperty} implementations.
+ */
+@SuppressWarnings("javadoc")
+public abstract class AbstractMetaPropertyTest {
+
+    //-------------------------------------------------------------------------
+
+    @Test
+    public final void metaBean_compareWithConstructionArgument_same()
+            throws Exception {
+        MetaBean metaBean = mock(MetaBean.class);
+        MetaProperty<?> metaProperty = createObjectMetaPropertyWithMetaBean(metaBean);
+        assertSame(metaBean, metaProperty.metaBean());
+    }
+
+    @Test
+    public final void declaringClass_compareWithBeanClass_same()
+            throws Exception {
+        MetaProperty<?> metaProperty = createObjectMetaProperty();
+        assertSame(TestBean.class, metaProperty.declaringClass());
+    }
+
+    @Test
+    public final void name_compareWithConstructionArgument_equals()
+            throws Exception {
+        String name = "thePropertyName";
+        MetaProperty<?> metaProperty = createObjectMetaPropertyWithName(name);
+        assertEquals(name, metaProperty.name());
+    }
+
+    @Test
+    public final void propertyType_compareWithIntendedType_same()
+            throws Exception {
+        MetaProperty<Object> objectMetaProperty = createObjectMetaProperty();
+        assertSame(Object.class, objectMetaProperty.propertyType());
+
+        MetaProperty<String> stringMetaProperty = createStringMetaProperty();
+        assertSame(String.class, stringMetaProperty.propertyType());
+
+        MetaProperty<Integer> primitiveIntegerMetaProperty =
+                createPrimitiveIntegerMetaProperty();
+        assertSame(Integer.class, primitiveIntegerMetaProperty.propertyType());
+
+        MetaProperty<Integer> integerMetaProperty = createIntegerMetaProperty();
+        assertSame(Integer.class, integerMetaProperty.propertyType());
+
+        MetaProperty<List<Double>> doubleListMetaProperty =
+                createDoubleListMetaProperty();
+        assertSame(List.class, doubleListMetaProperty.propertyType());
+    }
+
+    // TODO add tests for 'propertyGenericType'  
+
+    // annotations ------------------------------------------------------------
+
+    @Test
+    public final void annotations_propertyWithoutAnnotations_reportsNoAnnotations()
+            throws Exception {
+        MetaProperty<?> notAnnotatedMetaProperty = createObjectMetaProperty();
+        Stream<Annotation> annotations = notAnnotatedMetaProperty.annotations();
+        assertEquals(0, annotations.count());
+    }
+
+    @Test
+    public final void annotations_propertyWithAnnotations_reportsCorrectAnnotations()
+            throws Exception {
+        MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
+
+        // reports exactly 1 annotation
+        Stream<Annotation> annotations = annotatedMetaProperty.annotations();
+        assertEquals(1, annotations.count());
+
+        // reports an annotation of the correct type
+        annotations = annotatedMetaProperty.annotations();
+        Stream<Annotation> anyAnnotations =
+                annotations.filter(a -> a instanceof AnyAnnotation);
+        assertEquals(1, anyAnnotations.count());
+    }
+
+    /*
+     * More detailed annotation processing must be tested in subclasses because
+     * its results differ depending on the strategy chosen to access the
+     * property (e.g. reflection on fields vs. reflection on methods). 
+     */
+
+    // boolean indicators -----------------------------------------------------
+
+    // TODO add tests for 'isDerived', 'isBuildable'
+
+    @Test
+    public final void isMutable_mutableProperty_true() throws Exception {
+        MetaProperty<?> metaProperty = createObjectMetaProperty();
+        assertTrue(metaProperty.isMutable());
+    }
+
+    @Test
+    public final void isMutable_readOnlyProperty_false() throws Exception {
+        MetaProperty<?> readOnlyMetaProperty = createReadOnlyObjectMetaProperty();
+        assertFalse(readOnlyMetaProperty.isMutable());
+    }
+
+    // get & set --------------------------------------------------------------
+
+    @Test
+    public final void get_valueNull_null() throws Exception {
+        MetaProperty<?> metaProperty = createObjectMetaProperty();
+        TestBean bean = createBean();
+        assertNull(metaProperty.get(bean));
+    }
+
+    @Test
+    public final void get_existingValue_sameValue() throws Exception {
+        MetaProperty<String> stringMetaProperty = createStringMetaProperty();
+
+        TestBean bean = createBean();
+        String value = "the not null value";
+        bean.setString(value);
+
+        assertSame(value, stringMetaProperty.get(bean));
+    }
+
+    @Test(expected = ClassCastException.class)
+    public final void get_incorrectBeanType_ClassCastException()
+            throws Exception {
+        MetaProperty<?> metaProperty = createObjectMetaProperty();
+        metaProperty.get("this is no bean");
+    }
+
+    @Test
+    public final void set_nullForObject_valueIsNull() throws Exception {
+        MetaProperty<Integer> integerMetaProperty = createIntegerMetaProperty();
+
+        TestBean bean = createBean();
+        bean.setInteger(42);
+        assertEquals((Integer) 42, bean.getInteger());
+        integerMetaProperty.set(bean, null);
+
+        assertNull(bean.getInteger());
+    }
+
+    @Test
+    public final void set_some_valueIsSame() throws Exception {
+        MetaProperty<List<Double>> doubleListMetaProperty =
+                createDoubleListMetaProperty();
+
+        TestBean bean = createBean();
+        List<Double> doubleList =
+                Stream.of(1d, 2d, 8d, 42d, 63d).collect(Collectors.toList());
+        doubleListMetaProperty.set(bean, doubleList);
+
+        assertSame(doubleList, bean.getDoubleList());
+    }
+
+    @Test(expected = ClassCastException.class)
+    public final void set_incorrectBeanType_ClassCastException()
+            throws Exception {
+        MetaProperty<?> metaProperty = createObjectMetaProperty();
+        metaProperty.set("this is no bean", null);
+    }
+
+    @Test(expected = ClassCastException.class)
+    public final void set_incorrectValueType_ClassCastException()
+            throws Exception {
+        MetaProperty<Integer> integerMetaProperty = createIntegerMetaProperty();
+        TestBean bean = createBean();
+        integerMetaProperty.set(bean, "this is no integer");
+    }
+
+    @Test(expected = RuntimeException.class)
+    public final void set_rejectedValue_RuntimeException() throws Exception {
+        MetaProperty<Integer> primitiveIntegerMetaProperty =
+                createPrimitiveIntegerMetaProperty();
+
+        TestBean bean = createBean();
+        // a primitive int field rejects nulls
+        Integer rejectedValue = null;
+        primitiveIntegerMetaProperty.set(bean, rejectedValue);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public final void set_readOnlyMetaProperty_UnsupportedOperationException()
+            throws Exception {
+        MetaProperty<?> readOnlyMetaProperty = createReadOnlyObjectMetaProperty();
+        TestBean bean = createBean();
+        readOnlyMetaProperty.set(bean, "some Value");
+    }
+
+    // equals & hashCode-------------------------------------------------------
+
+    // TODO add tests for 'equals', 'hashCode'
+
+    /* 
+     * abstract test methods --------------------------------------------------
+     */
+
+    protected abstract TestBean createBean();
+
+    /*
+     * All methods must return "fully functional" meta-properties.
+     * This implies that each returned meta-property fulfills these conditions:
+     *  - is a property for {@link TestBean}
+     *  - its name is derived from the corresponding bean getter
+     *      e.g. "getDoubleList()" -> "doubleList"
+     *  - annotations (only tested superficially in this class):
+     *     - reports no annotations on the object property
+     *     - reports 'AnyAnnotation' on the string property
+     *  - is not derived
+     *  - is buildable 
+     *  - is mutable, i.e. not read-only
+     *  - accepts all values valid for the corresponding bean setter
+     *  
+     * Divergent behavior is specified by the factory method's name.
+     */
+
+    protected abstract MetaProperty<Object> createObjectMetaProperty()
+            throws Exception;
+
+    protected abstract MetaProperty<Object> createObjectMetaPropertyWithMetaBean(
+            MetaBean metaBean)
+            throws Exception;
+
+    protected abstract MetaProperty<Object> createObjectMetaPropertyWithName(
+            String name)
+            throws Exception;
+
+    protected abstract MetaProperty<Object> createReadOnlyObjectMetaProperty()
+            throws Exception;
+
+    protected abstract MetaProperty<String> createStringMetaProperty()
+            throws Exception;
+
+    protected abstract MetaProperty<Integer> createPrimitiveIntegerMetaProperty()
+            throws Exception;
+
+    protected abstract MetaProperty<Integer> createIntegerMetaProperty()
+            throws Exception;
+
+    protected abstract MetaProperty<List<Double>> createDoubleListMetaProperty()
+            throws Exception;
+
+}

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -38,7 +38,7 @@ public abstract class AbstractMetaPropertyTest {
     public final void declaringClass_compareWithBeanClass_same()
             throws Exception {
         MetaProperty<?> metaProperty = createObjectMetaProperty();
-        assertSame(TestBean.class, metaProperty.declaringClass());
+        assertSame(TestBean.class, metaProperty.declaringType());
     }
 
     @Test

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -87,15 +87,15 @@ public abstract class AbstractMetaPropertyTest {
             throws Exception {
         MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
 
-        // reports exactly 1 annotation
+        // reports at least one annotation
         Stream<Annotation> annotations = annotatedMetaProperty.annotations();
-        assertEquals(annotations.count(), 1);
+        assertTrue(annotations.count() >= 1);
 
-        // reports an annotation of the correct type
+        // reports only annotations of the correct type
         annotations = annotatedMetaProperty.annotations();
-        Stream<Annotation> anyAnnotations =
-                annotations.filter(a -> a instanceof AnyAnnotation);
-        assertEquals(anyAnnotations.count(), 1);
+        Stream<Annotation> otherAnnotations =
+                annotations.filter(a -> !(a instanceof AnyAnnotation));
+        assertEquals(otherAnnotations.count(), 0);
     }
 
     /*

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -31,14 +31,14 @@ public abstract class AbstractMetaPropertyTest {
             throws Exception {
         MetaBean metaBean = mock(MetaBean.class);
         MetaProperty<?> metaProperty = createObjectMetaPropertyWithMetaBean(metaBean);
-        assertSame(metaBean, metaProperty.metaBean());
+        assertSame(metaProperty.metaBean(), metaBean);
     }
 
     @Test
     public final void declaringClass_compareWithBeanClass_same()
             throws Exception {
         MetaProperty<?> metaProperty = createObjectMetaProperty();
-        assertSame(TestBean.class, metaProperty.declaringType());
+        assertSame(metaProperty.declaringType(), TestBean.class);
     }
 
     @Test
@@ -46,28 +46,28 @@ public abstract class AbstractMetaPropertyTest {
             throws Exception {
         String name = "thePropertyName";
         MetaProperty<?> metaProperty = createObjectMetaPropertyWithName(name);
-        assertEquals(name, metaProperty.name());
+        assertEquals(metaProperty.name(), name);
     }
 
     @Test
     public final void propertyType_compareWithIntendedType_same()
             throws Exception {
         MetaProperty<Object> objectMetaProperty = createObjectMetaProperty();
-        assertSame(Object.class, objectMetaProperty.propertyType());
+        assertSame(objectMetaProperty.propertyType(), Object.class);
 
         MetaProperty<String> stringMetaProperty = createStringMetaProperty();
-        assertSame(String.class, stringMetaProperty.propertyType());
+        assertSame(stringMetaProperty.propertyType(), String.class);
 
         MetaProperty<Integer> primitiveIntegerMetaProperty =
                 createPrimitiveIntegerMetaProperty();
-        assertSame(int.class, primitiveIntegerMetaProperty.propertyType());
+        assertSame(primitiveIntegerMetaProperty.propertyType(), int.class);
 
         MetaProperty<Integer> integerMetaProperty = createIntegerMetaProperty();
-        assertSame(Integer.class, integerMetaProperty.propertyType());
+        assertSame(integerMetaProperty.propertyType(), Integer.class);
 
         MetaProperty<List<Double>> doubleListMetaProperty =
                 createDoubleListMetaProperty();
-        assertSame(List.class, doubleListMetaProperty.propertyType());
+        assertSame(doubleListMetaProperty.propertyType(), List.class);
     }
 
     // TODO add tests for 'propertyGenericType'  
@@ -79,7 +79,7 @@ public abstract class AbstractMetaPropertyTest {
             throws Exception {
         MetaProperty<?> notAnnotatedMetaProperty = createObjectMetaProperty();
         Stream<Annotation> annotations = notAnnotatedMetaProperty.annotations();
-        assertEquals(0, annotations.count());
+        assertEquals(annotations.count(), 0);
     }
 
     @Test
@@ -89,13 +89,13 @@ public abstract class AbstractMetaPropertyTest {
 
         // reports exactly 1 annotation
         Stream<Annotation> annotations = annotatedMetaProperty.annotations();
-        assertEquals(1, annotations.count());
+        assertEquals(annotations.count(), 1);
 
         // reports an annotation of the correct type
         annotations = annotatedMetaProperty.annotations();
         Stream<Annotation> anyAnnotations =
                 annotations.filter(a -> a instanceof AnyAnnotation);
-        assertEquals(1, anyAnnotations.count());
+        assertEquals(anyAnnotations.count(), 1);
     }
 
     /*
@@ -137,7 +137,7 @@ public abstract class AbstractMetaPropertyTest {
         String value = "the not null value";
         bean.setString(value);
 
-        assertSame(value, stringMetaProperty.get(bean));
+        assertSame(stringMetaProperty.get(bean), value);
     }
 
     @Test(expectedExceptions = ClassCastException.class)
@@ -161,7 +161,7 @@ public abstract class AbstractMetaPropertyTest {
 
         TestBean bean = createBean();
         bean.setInteger(42);
-        assertEquals((Integer) 42, bean.getInteger());
+        assertEquals(bean.getInteger(), (Integer) 42);
         integerMetaProperty.set(bean, null);
 
         assertNull(bean.getInteger());
@@ -177,7 +177,7 @@ public abstract class AbstractMetaPropertyTest {
                 Stream.of(1d, 2d, 8d, 42d, 63d).collect(Collectors.toList());
         doubleListMetaProperty.set(bean, doubleList);
 
-        assertSame(doubleList, bean.getDoubleList());
+        assertSame(bean.getDoubleList(), doubleList);
     }
 
     @Test(expectedExceptions = ClassCastException.class)

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -1,11 +1,11 @@
 package org.joda.pa;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 import java.lang.annotation.Annotation;
 import java.util.List;
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.joda.pa.TestBean.AnyAnnotation;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 /**
  * Abstract superclass to tests of {@link MetaProperty} implementations.
@@ -140,14 +140,14 @@ public abstract class AbstractMetaPropertyTest {
         assertSame(value, stringMetaProperty.get(bean));
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expectedExceptions = ClassCastException.class)
     public final void get_incorrectBeanType_ClassCastException()
             throws Exception {
         MetaProperty<?> metaProperty = createObjectMetaProperty();
         metaProperty.get("this is no bean");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public final void get_writeOnlyMetaProperty_UnsupportedOperationException()
             throws Exception {
         MetaProperty<?> readOnlyMetaProperty = createWriteOnlyObjectMetaProperty();
@@ -180,14 +180,14 @@ public abstract class AbstractMetaPropertyTest {
         assertSame(doubleList, bean.getDoubleList());
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expectedExceptions = ClassCastException.class)
     public final void set_incorrectBeanType_ClassCastException()
             throws Exception {
         MetaProperty<?> metaProperty = createObjectMetaProperty();
         metaProperty.set("this is no bean", null);
     }
 
-    @Test(expected = ClassCastException.class)
+    @Test(expectedExceptions = ClassCastException.class)
     public final void set_incorrectValueType_ClassCastException()
             throws Exception {
         MetaProperty<Integer> integerMetaProperty = createIntegerMetaProperty();
@@ -195,7 +195,7 @@ public abstract class AbstractMetaPropertyTest {
         integerMetaProperty.set(bean, "this is no integer");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expectedExceptions = RuntimeException.class)
     public final void set_rejectedValue_RuntimeException() throws Exception {
         MetaProperty<Integer> primitiveIntegerMetaProperty =
                 createPrimitiveIntegerMetaProperty();
@@ -206,7 +206,7 @@ public abstract class AbstractMetaPropertyTest {
         primitiveIntegerMetaProperty.set(bean, rejectedValue);
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public final void set_readOnlyMetaProperty_UnsupportedOperationException()
             throws Exception {
         MetaProperty<?> readOnlyMetaProperty = createReadOnlyObjectMetaProperty();

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -144,6 +144,14 @@ public abstract class AbstractMetaPropertyTest {
         metaProperty.get("this is no bean");
     }
 
+    @Test(expected = UnsupportedOperationException.class)
+    public final void get_writeOnlyMetaProperty_UnsupportedOperationException()
+            throws Exception {
+        MetaProperty<?> readOnlyMetaProperty = createWriteOnlyObjectMetaProperty();
+        TestBean bean = createBean();
+        readOnlyMetaProperty.get(bean);
+    }
+
     @Test
     public final void set_nullForObject_valueIsNull() throws Exception {
         MetaProperty<Integer> integerMetaProperty = createIntegerMetaProperty();
@@ -242,6 +250,9 @@ public abstract class AbstractMetaPropertyTest {
             throws Exception;
 
     protected abstract MetaProperty<Object> createReadOnlyObjectMetaProperty()
+            throws Exception;
+
+    protected abstract MetaProperty<Object> createWriteOnlyObjectMetaProperty()
             throws Exception;
 
     protected abstract MetaProperty<String> createStringMetaProperty()

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -8,6 +8,7 @@ import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -83,7 +84,7 @@ public abstract class AbstractMetaPropertyTest {
     }
 
     @Test
-    public final void annotations_propertyWithAnnotations_reportsCorrectAnnotations()
+    public final void annotations_propertyWithAnnotations_reportsAnnotations()
             throws Exception {
         MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
 
@@ -96,6 +97,35 @@ public abstract class AbstractMetaPropertyTest {
         Stream<Annotation> otherAnnotations =
                 annotations.filter(a -> !(a instanceof AnyAnnotation));
         assertEquals(otherAnnotations.count(), 0);
+    }
+
+    @Test
+    public final void annotationsFiltered_propertyWithoutAnnotations_reportsNoAnnotations()
+            throws Exception {
+        MetaProperty<?> notAnnotatedMetaProperty = createObjectMetaProperty();
+        Stream<? extends Annotation> annotations =
+                notAnnotatedMetaProperty.annotations(AnyAnnotation.class);
+        assertEquals(annotations.count(), 0);
+    }
+
+    @Test
+    public final void annotationsFiltered_propertyWithoutMatchingAnnotations_reportsNoAnnotations()
+            throws Exception {
+        MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
+        Stream<? extends Annotation> annotations =
+                annotatedMetaProperty.annotations(Retention.class);
+        assertEquals(annotations.count(), 0);
+    }
+
+    @Test
+    public final void annotationsFiltered_propertyWithMatchingAnnotations_reportsAnnotations()
+            throws Exception {
+        MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
+
+        // reports at least one annotation
+        Stream<AnyAnnotation> annotations =
+                annotatedMetaProperty.annotations(AnyAnnotation.class);
+        assertTrue(annotations.count() >= 1);
     }
 
     /*

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -7,6 +7,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -274,7 +275,48 @@ public abstract class AbstractMetaPropertyTest {
 
     // equals & hashCode-------------------------------------------------------
 
-    // TODO add tests for 'equals', 'hashCode'
+    @Test
+    public final void equals_otherBeanOtherName_false() throws Exception {
+        MetaProperty<?> objectMetaPropertyOnTestBean = createObjectMetaProperty();
+        MetaProperty<?> otherMetaPropertyOnSomeBean =
+                new ComparisonMetaProperty(
+                        AbstractMetaPropertyTest.class, "somePropertyName");
+
+        assertFalse(objectMetaPropertyOnTestBean
+                .equals(otherMetaPropertyOnSomeBean));
+    }
+
+    @Test
+    public final void equals_otherBeanSameName_false() throws Exception {
+        MetaProperty<?> objectMetaPropertyOnTestBean = createObjectMetaProperty();
+        MetaProperty<?> objectMetaPropertyOnSomeBean =
+                new ComparisonMetaProperty(
+                        AbstractMetaPropertyTest.class, "object");
+
+        assertFalse(objectMetaPropertyOnTestBean
+                .equals(objectMetaPropertyOnSomeBean));
+    }
+
+    @Test
+    public final void equals_sameBeanOtherName_false() throws Exception {
+        MetaProperty<?> objectMetaPropertyOnTestBean = createObjectMetaProperty();
+        MetaProperty<?> otherMetaPropertyOnTestBean =
+                new ComparisonMetaProperty(TestBean.class, "somePropertyName");
+
+        assertFalse(objectMetaPropertyOnTestBean
+                .equals(otherMetaPropertyOnTestBean));
+    }
+
+    @Test
+    public final void equals_sameBeanSameName_true() throws Exception {
+        MetaProperty<?> objectMetaPropertyOnTestBean = createObjectMetaProperty();
+        MetaProperty<?> equalMetaProperty =
+                new ComparisonMetaProperty(TestBean.class, "object");
+
+        assertTrue(objectMetaPropertyOnTestBean.equals(equalMetaProperty));
+    }
+
+    // TODO add tests for 'hashCode'
 
     /* 
      * abstract test methods --------------------------------------------------
@@ -334,5 +376,66 @@ public abstract class AbstractMetaPropertyTest {
 
     protected abstract MetaProperty<List<Double>> createDoubleListMetaProperty()
             throws Exception;
+
+    /* 
+     * inner classes ----------------------------------------------------------
+     */
+
+    private static class ComparisonMetaProperty implements MetaProperty<Void> {
+
+        private final Class<?> declaringType;
+        private final String name;
+
+        public ComparisonMetaProperty(Class<?> declaringType, String name) {
+            this.declaringType = declaringType;
+            this.name = name;
+        }
+
+        @Override
+        public MetaBean metaBean() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public Class<Void> propertyType() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Class<?> declaringType() {
+            return declaringType;
+        }
+
+        @Override
+        public Stream<Annotation> annotations() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isBuildable() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isMutable() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Void get(Object bean) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void set(Object bean, Object value) {
+            throw new UnsupportedOperationException();
+        }
+
+    }
 
 }

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -142,7 +142,29 @@ public abstract class AbstractMetaPropertyTest {
 
     // boolean indicators -----------------------------------------------------
 
-    // TODO add tests for 'isDerived', 'isBuildable'
+    @Test
+    public final void isDerived_derivedProperty_true() throws Exception {
+        MetaProperty<?> metaProperty = createDerivedObjectMetaProperty();
+        assertTrue(metaProperty.isDerived());
+    }
+
+    @Test
+    public final void isDerived_notDerivedProperty_false() throws Exception {
+        MetaProperty<?> readOnlyMetaProperty = createObjectMetaProperty();
+        assertFalse(readOnlyMetaProperty.isDerived());
+    }
+
+    @Test
+    public final void isBuildable_buildableProperty_true() throws Exception {
+        MetaProperty<?> metaProperty = createObjectMetaProperty();
+        assertTrue(metaProperty.isBuildable());
+    }
+
+    @Test
+    public final void isBuildable_notBuildableProperty_false() throws Exception {
+        MetaProperty<?> readOnlyMetaProperty = createNotBuildableObjectMetaProperty();
+        assertFalse(readOnlyMetaProperty.isBuildable());
+    }
 
     @Test
     public final void isMutable_mutableProperty_true() throws Exception {
@@ -292,6 +314,12 @@ public abstract class AbstractMetaPropertyTest {
             throws Exception;
 
     protected abstract MetaProperty<Object> createWriteOnlyObjectMetaProperty()
+            throws Exception;
+
+    protected abstract MetaProperty<Object> createDerivedObjectMetaProperty()
+            throws Exception;
+
+    protected abstract MetaProperty<Object> createNotBuildableObjectMetaProperty()
             throws Exception;
 
     protected abstract MetaProperty<String> createStringMetaProperty()

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -7,7 +7,6 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
-import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -79,8 +78,10 @@ public abstract class AbstractMetaPropertyTest {
     public final void annotations_propertyWithoutAnnotations_reportsNoAnnotations()
             throws Exception {
         MetaProperty<?> notAnnotatedMetaProperty = createObjectMetaProperty();
-        Stream<Annotation> annotations = notAnnotatedMetaProperty.annotations();
-        assertEquals(annotations.count(), 0);
+        long annotationsCount = notAnnotatedMetaProperty
+                .annotations()
+                .count();
+        assertEquals(annotationsCount, 0);
     }
 
     @Test
@@ -89,32 +90,36 @@ public abstract class AbstractMetaPropertyTest {
         MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
 
         // reports at least one annotation
-        Stream<Annotation> annotations = annotatedMetaProperty.annotations();
-        assertTrue(annotations.count() >= 1);
+        long annotationsCount = annotatedMetaProperty
+                .annotations()
+                .count();
+        assertTrue(annotationsCount >= 1);
 
         // reports only annotations of the correct type
-        annotations = annotatedMetaProperty.annotations();
-        Stream<Annotation> otherAnnotations =
-                annotations.filter(a -> !(a instanceof AnyAnnotation));
-        assertEquals(otherAnnotations.count(), 0);
+        boolean allAnnotationsOfCorrectType = annotatedMetaProperty
+                .annotations()
+                .allMatch(AnyAnnotation.class::isInstance);
+        assertTrue(allAnnotationsOfCorrectType);
     }
 
     @Test
     public final void annotationsFiltered_propertyWithoutAnnotations_reportsNoAnnotations()
             throws Exception {
         MetaProperty<?> notAnnotatedMetaProperty = createObjectMetaProperty();
-        Stream<? extends Annotation> annotations =
-                notAnnotatedMetaProperty.annotations(AnyAnnotation.class);
-        assertEquals(annotations.count(), 0);
+        long annotationsCount = notAnnotatedMetaProperty
+                .annotations()
+                .count();
+        assertEquals(annotationsCount, 0);
     }
 
     @Test
     public final void annotationsFiltered_propertyWithoutMatchingAnnotations_reportsNoAnnotations()
             throws Exception {
         MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
-        Stream<? extends Annotation> annotations =
-                annotatedMetaProperty.annotations(Retention.class);
-        assertEquals(annotations.count(), 0);
+        long notExistingAnnotationsCount = annotatedMetaProperty
+                .annotations(Retention.class)
+                .count();
+        assertEquals(notExistingAnnotationsCount, 0);
     }
 
     @Test
@@ -123,9 +128,10 @@ public abstract class AbstractMetaPropertyTest {
         MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
 
         // reports at least one annotation
-        Stream<AnyAnnotation> annotations =
-                annotatedMetaProperty.annotations(AnyAnnotation.class);
-        assertTrue(annotations.count() >= 1);
+        long annotationsCount = annotatedMetaProperty
+                .annotations(AnyAnnotation.class)
+                .count();
+        assertTrue(annotationsCount >= 1);
     }
 
     /*

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -291,10 +291,11 @@ public abstract class AbstractMetaPropertyTest {
      *  - annotations (only tested superficially in this class):
      *     - reports no annotations on the object property
      *     - reports 'AnyAnnotation' on the string property
+     *     - (other property annotations are not tested)
      *  - is not derived
      *  - is buildable 
      *  - is mutable, i.e. not read-only
-     *  - accepts all values valid for the corresponding bean setter
+     *  - accepts all values, which are valid for the corresponding bean setter
      *  
      * Divergent behavior is specified by the factory method's name.
      */

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -17,6 +17,9 @@ import org.junit.Test;
 
 /**
  * Abstract superclass to tests of {@link MetaProperty} implementations.
+ * <p>
+ * Inheriting classes only need to implement various factory methods to have
+ * their unit completely tested. 
  */
 @SuppressWarnings("javadoc")
 public abstract class AbstractMetaPropertyTest {
@@ -57,7 +60,7 @@ public abstract class AbstractMetaPropertyTest {
 
         MetaProperty<Integer> primitiveIntegerMetaProperty =
                 createPrimitiveIntegerMetaProperty();
-        assertSame(Integer.class, primitiveIntegerMetaProperty.propertyType());
+        assertSame(int.class, primitiveIntegerMetaProperty.propertyType());
 
         MetaProperty<Integer> integerMetaProperty = createIntegerMetaProperty();
         assertSame(Integer.class, integerMetaProperty.propertyType());

--- a/src/test/java/org/joda/pa/FieldBackedTestBean.java
+++ b/src/test/java/org/joda/pa/FieldBackedTestBean.java
@@ -34,11 +34,13 @@ final class FieldBackedTestBean implements TestBean {
     }
 
     @Override
+    @AnyAnnotation
     public String getString() {
         return string;
     }
 
     @Override
+    @AnyAnnotation
     public void setString(String string) {
         this.string = string;
     }
@@ -54,11 +56,13 @@ final class FieldBackedTestBean implements TestBean {
     }
 
     @Override
+    @GetAnnotation
     public Integer getInteger() {
         return integer;
     }
 
     @Override
+    @SetAnnotation
     public void setInteger(Integer integer) {
         this.integer = integer;
     }

--- a/src/test/java/org/joda/pa/FieldBackedTestBean.java
+++ b/src/test/java/org/joda/pa/FieldBackedTestBean.java
@@ -1,0 +1,76 @@
+package org.joda.pa;
+
+import java.util.List;
+
+/**
+ * Acts as the bean class for all tests. 
+ */
+final class FieldBackedTestBean implements TestBean {
+
+    // fields
+
+    private Object object;
+
+    @AnyAnnotation
+    private String string;
+
+    @FieldAnnotation
+    private int primitiveInteger;
+
+    private Integer integer;
+
+    private List<Double> doubleList;
+
+    // field access
+
+    @Override
+    public Object getObject() {
+        return object;
+    }
+
+    @Override
+    public void setObject(Object object) {
+        this.object = object;
+    }
+
+    @Override
+    public String getString() {
+        return string;
+    }
+
+    @Override
+    public void setString(String string) {
+        this.string = string;
+    }
+
+    @Override
+    public int getPrimitiveInteger() {
+        return primitiveInteger;
+    }
+
+    @Override
+    public void setPrimitiveInteger(int primitiveInteger) {
+        this.primitiveInteger = primitiveInteger;
+    }
+
+    @Override
+    public Integer getInteger() {
+        return integer;
+    }
+
+    @Override
+    public void setInteger(Integer integer) {
+        this.integer = integer;
+    }
+
+    @Override
+    public List<Double> getDoubleList() {
+        return doubleList;
+    }
+
+    @Override
+    public void setDoubleList(List<Double> doubleList) {
+        this.doubleList = doubleList;
+    }
+
+}

--- a/src/test/java/org/joda/pa/FieldBackedTestBean.java
+++ b/src/test/java/org/joda/pa/FieldBackedTestBean.java
@@ -14,9 +14,9 @@ final class FieldBackedTestBean implements TestBean {
     @AnyAnnotation
     private String string;
 
-    @FieldAnnotation
     private int primitiveInteger;
 
+    @FieldAnnotation
     private Integer integer;
 
     private List<Double> doubleList;

--- a/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
@@ -3,10 +3,9 @@ package org.joda.pa;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
-import java.util.stream.Stream;
 
 import org.joda.pa.TestBean.FieldAnnotation;
 import org.testng.annotations.Test;
@@ -24,15 +23,16 @@ public class FieldMetaPropertyTest extends
         MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
 
         // report exactly one annotation
-        Stream<Annotation> annotations = annotatedMetaProperty.annotations();
-        assertEquals(annotations.count(), 1);
+        long annotationsCount = annotatedMetaProperty
+                .annotations()
+                .count();
+        assertEquals(annotationsCount, 1);
 
         // report an annotation of the correct type
-        long annotationsOnField = annotatedMetaProperty
+        boolean annotationOfCorrectType = annotatedMetaProperty
                 .annotations()
-                .filter(FieldAnnotation.class::isInstance)
-                .count();
-        assertEquals(annotationsOnField, 1);
+                .allMatch(FieldAnnotation.class::isInstance);
+        assertTrue(annotationOfCorrectType);
     }
 
     @Test
@@ -41,9 +41,10 @@ public class FieldMetaPropertyTest extends
         MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
 
         // report exactly one annotation
-        Stream<? extends Annotation> annotationsOnField =
-                annotatedMetaProperty.annotations(FieldAnnotation.class);
-        assertEquals(annotationsOnField.count(), 1);
+        long annotationsCount = annotatedMetaProperty
+                .annotations(FieldAnnotation.class)
+                .count();
+        assertEquals(annotationsCount, 1);
     }
 
     // implementation of 'AbstractFieldNameBasedMetaPropertyTest' -------------

--- a/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
@@ -4,89 +4,15 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.Field;
-import java.util.List;
 
 /**
  * Tests the class {@link FieldMetaProperty}.
  */
-public class FieldMetaPropertyTest extends AbstractMetaPropertyTest {
+public class FieldMetaPropertyTest extends
+        AbstractFieldNameBasedMetaPropertyTest {
 
     @Override
-    protected TestBean createBean() {
-        return new FieldBackedTestBean();
-    }
-
-    @Override
-    protected MetaProperty<Object> createObjectMetaProperty() throws Exception {
-        return createMetaProperty(null, Object.class, "object");
-    }
-
-    @Override
-    protected MetaProperty<Object> createObjectMetaPropertyWithMetaBean(
-            MetaBean metaBean)
-            throws Exception {
-        return createMetaProperty(metaBean, Object.class, "object");
-    }
-
-    @Override
-    protected MetaProperty<Object> createObjectMetaPropertyWithName(String name)
-            throws Exception {
-        return createMetaProperty(
-                null, name, Object.class, false, true, true, true, "object");
-    }
-
-    @Override
-    protected MetaProperty<Object> createReadOnlyObjectMetaProperty()
-            throws Exception {
-        return createMetaProperty(
-                null, "object", Object.class,
-                false, true, true, false, "object");
-    }
-
-    @Override
-    protected MetaProperty<Object> createWriteOnlyObjectMetaProperty()
-            throws Exception {
-        return createMetaProperty(
-                null, "object", Object.class,
-                false, true, false, true, "object");
-    }
-
-    @Override
-    protected MetaProperty<String> createStringMetaProperty() throws Exception {
-        return createMetaProperty(null, String.class, "string");
-    }
-
-    @Override
-    protected MetaProperty<Integer> createPrimitiveIntegerMetaProperty()
-            throws Exception {
-        return createMetaProperty(null, Integer.class, "primitiveInteger");
-    }
-
-    @Override
-    protected MetaProperty<Integer> createIntegerMetaProperty()
-            throws Exception {
-        return createMetaProperty(null, Integer.class, "integer");
-    }
-
-    @Override
-    protected MetaProperty<List<Double>> createDoubleListMetaProperty()
-            throws Exception {
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        // TODO is there a nicer way to do this?
-        Class<List<Double>> typeToken = ((Class) List.class);
-        return createMetaProperty(null, typeToken, "doubleList");
-    }
-
-    private static <P> MetaProperty<P> createMetaProperty(
-            MetaBean metaBean, Class<P> typeToken, String fieldName)
-            throws Exception {
-
-        return createMetaProperty(
-                metaBean, fieldName, typeToken, false, true, true, true,
-                fieldName);
-    }
-
-    private static <P> MetaProperty<P> createMetaProperty(
+    protected <P> MetaProperty<P> createMetaProperty(
             MetaBean metaBean, String name, Class<P> typeToken,
             boolean derived, boolean buildable,
             boolean readable, boolean mutable,

--- a/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
@@ -1,0 +1,98 @@
+package org.joda.pa;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+/**
+ * Tests the class {@link FieldMetaProperty}.
+ */
+public class FieldMetaPropertyTest extends AbstractMetaPropertyTest {
+
+    @Override
+    protected TestBean createBean() {
+        return new FieldBackedTestBean();
+    }
+
+    @Override
+    protected MetaProperty<Object> createObjectMetaProperty() throws Exception {
+        return createMetaProperty(null, Object.class, "object");
+    }
+
+    @Override
+    protected MetaProperty<Object> createObjectMetaPropertyWithMetaBean(
+            MetaBean metaBean)
+            throws Exception {
+        return createMetaProperty(metaBean, Object.class, "object");
+    }
+
+    @Override
+    protected MetaProperty<Object> createObjectMetaPropertyWithName(String name)
+            throws Exception {
+        return createMetaProperty(
+                null, name, Object.class, true, false, true, "object");
+    }
+
+    @Override
+    protected MetaProperty<Object> createReadOnlyObjectMetaProperty()
+            throws Exception {
+        return createMetaProperty(
+                null, "object", Object.class, true, false, false, "object");
+    }
+
+    @Override
+    protected MetaProperty<String> createStringMetaProperty() throws Exception {
+        return createMetaProperty(null, String.class, "string");
+    }
+
+    @Override
+    protected MetaProperty<Integer> createPrimitiveIntegerMetaProperty()
+            throws Exception {
+        return createMetaProperty(null, Integer.class, "primitiveInteger");
+    }
+
+    @Override
+    protected MetaProperty<Integer> createIntegerMetaProperty()
+            throws Exception {
+        return createMetaProperty(null, Integer.class, "integer");
+    }
+
+    @Override
+    protected MetaProperty<List<Double>> createDoubleListMetaProperty()
+            throws Exception {
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        // TODO is there a nicer way to do this?
+        Class<List<Double>> typeToken = ((Class) List.class);
+        return createMetaProperty(null, typeToken, "doubleList");
+    }
+
+    private static <P> MetaProperty<P> createMetaProperty(
+            MetaBean metaBean, Class<P> typeToken, String fieldName)
+            throws Exception {
+
+        return createMetaProperty(
+                metaBean, fieldName, typeToken, true, false, true, fieldName);
+    }
+
+    private static <P> MetaProperty<P> createMetaProperty(
+            MetaBean metaBean, String name, Class<P> typeToken,
+            boolean buildable, boolean derived, boolean mutable,
+            String fieldName)
+            throws Exception {
+
+        MetaBean notNullMetaBean = metaBean;
+        if (notNullMetaBean == null) {
+            notNullMetaBean = mock(MetaBean.class);
+            doReturn(TestBean.class).when(metaBean).beanType();
+        }
+        Field backingField =
+                FieldBackedTestBean.class.getDeclaredField(fieldName);
+
+        return new FieldMetaProperty<>(
+                notNullMetaBean, name, typeToken,
+                buildable, derived, mutable,
+                backingField);
+    }
+}

--- a/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
@@ -2,14 +2,51 @@ package org.joda.pa;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.util.stream.Stream;
+
+import org.joda.pa.TestBean.FieldAnnotation;
+import org.testng.annotations.Test;
 
 /**
  * Tests the class {@link FieldMetaProperty}.
  */
+@SuppressWarnings("javadoc")
 public class FieldMetaPropertyTest extends
         AbstractFieldNameBasedMetaPropertyTest {
+
+    @Test
+    public final void annotations_fieldWithAnnotation_reportsAnnotation()
+            throws Exception {
+        MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
+
+        // report exactly one annotation
+        Stream<Annotation> annotations = annotatedMetaProperty.annotations();
+        assertEquals(annotations.count(), 1);
+
+        // report an annotation of the correct type
+        long annotationsOnField = annotatedMetaProperty
+                .annotations()
+                .filter(FieldAnnotation.class::isInstance)
+                .count();
+        assertEquals(annotationsOnField, 1);
+    }
+
+    @Test
+    public final void annotationsFiltered_fieldWithAnnotation_reportsAnnotation()
+            throws Exception {
+        MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
+
+        // report exactly one annotation
+        Stream<? extends Annotation> annotationsOnField =
+                annotatedMetaProperty.annotations(FieldAnnotation.class);
+        assertEquals(annotationsOnField.count(), 1);
+    }
+
+    // implementation of 'AbstractFieldNameBasedMetaPropertyTest' -------------
 
     @Override
     protected <P> MetaProperty<P> createMetaProperty(

--- a/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
@@ -85,7 +85,7 @@ public class FieldMetaPropertyTest extends AbstractMetaPropertyTest {
         MetaBean notNullMetaBean = metaBean;
         if (notNullMetaBean == null) {
             notNullMetaBean = mock(MetaBean.class);
-            doReturn(TestBean.class).when(metaBean).beanType();
+            doReturn(TestBean.class).when(notNullMetaBean).beanType();
         }
         Field backingField =
                 FieldBackedTestBean.class.getDeclaredField(fieldName);

--- a/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
@@ -32,14 +32,23 @@ public class FieldMetaPropertyTest extends AbstractMetaPropertyTest {
     protected MetaProperty<Object> createObjectMetaPropertyWithName(String name)
             throws Exception {
         return createMetaProperty(
-                null, name, Object.class, true, false, true, "object");
+                null, name, Object.class, false, true, true, true, "object");
     }
 
     @Override
     protected MetaProperty<Object> createReadOnlyObjectMetaProperty()
             throws Exception {
         return createMetaProperty(
-                null, "object", Object.class, true, false, false, "object");
+                null, "object", Object.class,
+                false, true, true, false, "object");
+    }
+
+    @Override
+    protected MetaProperty<Object> createWriteOnlyObjectMetaProperty()
+            throws Exception {
+        return createMetaProperty(
+                null, "object", Object.class,
+                false, true, false, true, "object");
     }
 
     @Override
@@ -73,12 +82,14 @@ public class FieldMetaPropertyTest extends AbstractMetaPropertyTest {
             throws Exception {
 
         return createMetaProperty(
-                metaBean, fieldName, typeToken, true, false, true, fieldName);
+                metaBean, fieldName, typeToken, false, true, true, true,
+                fieldName);
     }
 
     private static <P> MetaProperty<P> createMetaProperty(
             MetaBean metaBean, String name, Class<P> typeToken,
-            boolean buildable, boolean derived, boolean mutable,
+            boolean derived, boolean buildable,
+            boolean readable, boolean mutable,
             String fieldName)
             throws Exception {
 
@@ -92,7 +103,7 @@ public class FieldMetaPropertyTest extends AbstractMetaPropertyTest {
 
         return new FieldMetaProperty<>(
                 notNullMetaBean, name, typeToken,
-                buildable, derived, mutable,
+                derived, buildable, readable, mutable,
                 backingField);
     }
 }

--- a/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
@@ -1,0 +1,130 @@
+package org.joda.pa;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * Tests the class {@link FunctionalMetaProperty}.
+ */
+public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
+
+    @Override
+    protected TestBean createBean() {
+        return new FieldBackedTestBean();
+    }
+
+    @Override
+    protected MetaProperty<Object> createObjectMetaProperty() {
+        return createObjectMetaProperty(null, "object");
+    }
+
+    @Override
+    protected MetaProperty<Object> createObjectMetaPropertyWithMetaBean(
+            MetaBean metaBean) {
+        return createObjectMetaProperty(metaBean, "object");
+    }
+
+    @Override
+    protected MetaProperty<Object> createObjectMetaPropertyWithName(String name) {
+        return createObjectMetaProperty(null, name);
+    }
+
+    @Override
+    protected MetaProperty<Object> createReadOnlyObjectMetaProperty() {
+        return createMetaProperty(
+                null, "object", Object.class, TestBean::getString, null, null);
+    }
+
+    private static MetaProperty<Object> createObjectMetaProperty(
+            MetaBean metaBean, String name) {
+        return createMetaProperty(
+                metaBean, name, Object.class,
+                TestBean::getObject, TestBean::setObject, null);
+    }
+
+    @Override
+    protected MetaProperty<String> createStringMetaProperty() {
+        Function<TestBean, String> getValue = TestBean::getString;
+        BiConsumer<TestBean, String> setValue = TestBean::setString;
+        Supplier<Stream<Annotation>> annotations =
+                FunctionalMetaPropertyTest::getStringFieldAnnotations;
+        return createMetaProperty(
+                null, "string", String.class, getValue, setValue, annotations);
+    }
+
+    private static Stream<Annotation> getStringFieldAnnotations() {
+        try {
+            Field stringField = FieldBackedTestBean.class
+                    .getDeclaredField("string");
+            Annotation[] annots = stringField.getAnnotations();
+            return Stream.of(annots);
+        } catch (NoSuchFieldException | SecurityException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    protected MetaProperty<Integer> createPrimitiveIntegerMetaProperty() {
+        Function<TestBean, Integer> getValue = TestBean::getPrimitiveInteger;
+        BiConsumer<TestBean, Integer> setValue = TestBean::setPrimitiveInteger;
+        return createMetaProperty(
+                null, "primitiveInteger", Integer.class,
+                getValue, setValue, null);
+    }
+
+    @Override
+    protected MetaProperty<Integer> createIntegerMetaProperty() {
+        Function<TestBean, Integer> getValue = TestBean::getInteger;
+        BiConsumer<TestBean, Integer> setValue = TestBean::setInteger;
+        return createMetaProperty(
+                null, "integer", Integer.class, getValue, setValue, null);
+    }
+
+    @Override
+    protected MetaProperty<List<Double>> createDoubleListMetaProperty() {
+        Function<TestBean, List<Double>> getValue = TestBean::getDoubleList;
+        BiConsumer<TestBean, List<Double>> setValue = TestBean::setDoubleList;
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        // TODO is there a nicer way to do this?
+        Class<List<Double>> typeToken = ((Class) List.class);
+        return createMetaProperty(
+                null, "doubleList", typeToken, getValue, setValue, null);
+    }
+
+    private static <P> MetaProperty<P> createMetaProperty(
+            MetaBean metaBean, String name, Class<P> typeToken,
+            Function<TestBean, P> getValue, BiConsumer<TestBean, P> setValue,
+            Supplier<Stream<Annotation>> annotations) {
+
+        MetaBean notNullMetaBean = metaBean;
+        if (notNullMetaBean == null) {
+            notNullMetaBean = mock(MetaBean.class);
+            doReturn(TestBean.class).when(metaBean).beanType();
+        }
+
+        Function<Object, P> get = getValue == null
+                ? null
+                : b -> getValue.apply((TestBean) b);
+        BiConsumer<Object, P> set = setValue == null
+                ? null
+                : (b, value) -> setValue.accept((TestBean) b, value);
+
+        Supplier<Stream<Annotation>> notNullAnnotations = annotations;
+        if (notNullAnnotations == null) {
+            notNullAnnotations = () -> Stream.empty();
+        }
+
+        return new FunctionalMetaProperty<>(
+                notNullMetaBean, name, typeToken, true, true,
+                get, set, notNullAnnotations);
+    }
+
+}

--- a/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
@@ -82,7 +82,7 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
         Function<TestBean, Integer> getValue = TestBean::getPrimitiveInteger;
         BiConsumer<TestBean, Integer> setValue = TestBean::setPrimitiveInteger;
         return createMetaProperty(
-                null, "primitiveInteger", Integer.class,
+                null, "primitiveInteger", int.class,
                 getValue, setValue, null);
     }
 

--- a/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
@@ -104,36 +104,50 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
 
     @Override
     protected MetaProperty<Object> createObjectMetaProperty() {
-        return createObjectMetaProperty(null, "object");
+        return createMetaProperty(
+                "object", Object.class,
+                TestBean::getObject, TestBean::setObject);
     }
 
     @Override
     protected MetaProperty<Object> createObjectMetaPropertyWithMetaBean(
             MetaBean metaBean) {
-        return createObjectMetaProperty(metaBean, "object");
+        return createMetaProperty(
+                metaBean, "object", Object.class,
+                TestBean::getObject, TestBean::setObject, null);
     }
 
     @Override
     protected MetaProperty<Object> createObjectMetaPropertyWithName(String name) {
-        return createObjectMetaProperty(null, name);
+        return createMetaProperty(
+                name, Object.class, TestBean::getObject, TestBean::setObject);
     }
 
     @Override
     protected MetaProperty<Object> createReadOnlyObjectMetaProperty() {
         return createMetaProperty(
-                null, "object", Object.class, TestBean::getObject, null, null);
+                "object", Object.class, TestBean::getObject, null);
     }
 
     @Override
     protected MetaProperty<Object> createWriteOnlyObjectMetaProperty() {
         return createMetaProperty(
-                null, "object", Object.class, null, TestBean::setObject, null);
+                "object", Object.class, null, TestBean::setObject);
     }
 
-    private static MetaProperty<Object> createObjectMetaProperty(
-            MetaBean metaBean, String name) {
+    @Override
+    protected MetaProperty<Object> createDerivedObjectMetaProperty()
+            throws Exception {
         return createMetaProperty(
-                metaBean, name, Object.class,
+                null, "object", Object.class, true, true,
+                TestBean::getObject, TestBean::setObject, null);
+    }
+
+    @Override
+    protected MetaProperty<Object> createNotBuildableObjectMetaProperty()
+            throws Exception {
+        return createMetaProperty(
+                null, "object", Object.class, false, false,
                 TestBean::getObject, TestBean::setObject, null);
     }
 
@@ -190,8 +204,8 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
         Function<TestBean, Integer> getValue = TestBean::getPrimitiveInteger;
         BiConsumer<TestBean, Integer> setValue = TestBean::setPrimitiveInteger;
         return createMetaProperty(
-                null, "primitiveInteger", int.class,
-                getValue, setValue, null);
+                "primitiveInteger", int.class,
+                getValue, setValue);
     }
 
     @Override
@@ -212,12 +226,30 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
         @SuppressWarnings({ "unchecked", "rawtypes" })
         // TODO is there a nicer way to do this?
         Class<List<Double>> typeToken = ((Class) List.class);
+        return createMetaProperty("doubleList", typeToken, getValue, setValue);
+    }
+
+    private static <P> MetaProperty<P> createMetaProperty(
+            String name, Class<P> typeToken,
+            Function<TestBean, P> getValue, BiConsumer<TestBean, P> setValue) {
+
         return createMetaProperty(
-                null, "doubleList", typeToken, getValue, setValue, null);
+                null, name, typeToken, getValue, setValue, null);
     }
 
     private static <P> MetaProperty<P> createMetaProperty(
             MetaBean metaBean, String name, Class<P> typeToken,
+            Function<TestBean, P> getValue, BiConsumer<TestBean, P> setValue,
+            Supplier<Stream<Annotation>> annotations) {
+
+        return createMetaProperty(
+                metaBean, name, typeToken, false, true,
+                getValue, setValue, annotations);
+    }
+
+    private static <P> MetaProperty<P> createMetaProperty(
+            MetaBean metaBean, String name, Class<P> typeToken,
+            boolean derived, boolean buildable,
             Function<TestBean, P> getValue, BiConsumer<TestBean, P> setValue,
             Supplier<Stream<Annotation>> annotations) {
 
@@ -240,7 +272,7 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
         }
 
         return new FunctionalMetaProperty<>(
-                notNullMetaBean, name, typeToken, true, true,
+                notNullMetaBean, name, typeToken, derived, buildable,
                 get, set, notNullAnnotations);
     }
 

--- a/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
@@ -31,15 +31,17 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
             throws Exception {
         MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
 
-        // report all three annotations
-        Stream<Annotation> annotations = annotatedMetaProperty.annotations();
-        assertEquals(annotations.count(), 3);
+        // report exactly three annotation
+        long annotationsCount = annotatedMetaProperty
+                .annotations()
+                .count();
+        assertEquals(annotationsCount, 3);
 
         // report annotations of the correct type
-        boolean allOfCorrectType = annotatedMetaProperty
+        boolean annotationsOfCorrectType = annotatedMetaProperty
                 .annotations()
                 .allMatch(AnyAnnotation.class::isInstance);
-        assertTrue(allOfCorrectType);
+        assertTrue(annotationsOfCorrectType);
     }
 
     @Test
@@ -52,21 +54,21 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
         assertEquals(annotations.count(), 3);
 
         // report annotations of the correct type
-        long annotationsOnField = annotatedMetaProperty
+        long annotationsCountOnField = annotatedMetaProperty
                 .annotations()
                 .filter(FieldAnnotation.class::isInstance)
                 .count();
-        assertEquals(annotationsOnField, 1);
-        long annotationsOnSet = annotatedMetaProperty
-                .annotations()
-                .filter(SetAnnotation.class::isInstance)
-                .count();
-        assertEquals(annotationsOnSet, 1);
-        long annotationsOnGet = annotatedMetaProperty
+        assertEquals(annotationsCountOnField, 1);
+        long annotationsCountOnGet = annotatedMetaProperty
                 .annotations()
                 .filter(GetAnnotation.class::isInstance)
                 .count();
-        assertEquals(annotationsOnGet, 1);
+        assertEquals(annotationsCountOnGet, 1);
+        long annotationsCountOnSet = annotatedMetaProperty
+                .annotations()
+                .filter(SetAnnotation.class::isInstance)
+                .count();
+        assertEquals(annotationsCountOnSet, 1);
     }
 
     @Test
@@ -75,19 +77,22 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
         MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
 
         // report exactly one field annotation
-        Stream<? extends Annotation> annotationsOnField =
-                annotatedMetaProperty.annotations(FieldAnnotation.class);
-        assertEquals(annotationsOnField.count(), 1);
+        long annotationsCountOnField = annotatedMetaProperty
+                .annotations(FieldAnnotation.class)
+                .count();
+        assertEquals(annotationsCountOnField, 1);
 
         // report exactly one get annotation
-        Stream<? extends Annotation> annotationsOnGet =
-                annotatedMetaProperty.annotations(GetAnnotation.class);
-        assertEquals(annotationsOnGet.count(), 1);
+        long annotationsCountOnGet = annotatedMetaProperty
+                .annotations(GetAnnotation.class)
+                .count();
+        assertEquals(annotationsCountOnGet, 1);
 
         // report exactly one set annotation
-        Stream<? extends Annotation> annotationsOnSet =
-                annotatedMetaProperty.annotations(SetAnnotation.class);
-        assertEquals(annotationsOnSet.count(), 1);
+        long annotationsCountOnSet = annotatedMetaProperty
+                .annotations(SetAnnotation.class)
+                .count();
+        assertEquals(annotationsCountOnSet, 1);
     }
 
     // implementation of 'AbstractMetaPropertyTest' -------------

--- a/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
@@ -224,7 +224,6 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
         Function<TestBean, List<Double>> getValue = TestBean::getDoubleList;
         BiConsumer<TestBean, List<Double>> setValue = TestBean::setDoubleList;
         @SuppressWarnings({ "unchecked", "rawtypes" })
-        // TODO is there a nicer way to do this?
         Class<List<Double>> typeToken = ((Class) List.class);
         return createMetaProperty("doubleList", typeToken, getValue, setValue);
     }

--- a/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
@@ -107,7 +107,7 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
         MetaBean notNullMetaBean = metaBean;
         if (notNullMetaBean == null) {
             notNullMetaBean = mock(MetaBean.class);
-            doReturn(TestBean.class).when(metaBean).beanType();
+            doReturn(TestBean.class).when(notNullMetaBean).beanType();
         }
 
         Function<Object, P> get = getValue == null

--- a/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
@@ -40,7 +40,13 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
     @Override
     protected MetaProperty<Object> createReadOnlyObjectMetaProperty() {
         return createMetaProperty(
-                null, "object", Object.class, TestBean::getString, null, null);
+                null, "object", Object.class, TestBean::getObject, null, null);
+    }
+
+    @Override
+    protected MetaProperty<Object> createWriteOnlyObjectMetaProperty() {
+        return createMetaProperty(
+                null, "object", Object.class, null, TestBean::setObject, null);
     }
 
     private static MetaProperty<Object> createObjectMetaProperty(

--- a/src/test/java/org/joda/pa/MethodMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/MethodMetaPropertyTest.java
@@ -20,7 +20,7 @@ public class MethodMetaPropertyTest extends
         AbstractFieldNameBasedMetaPropertyTest {
 
     @Test
-    public final void annotations_propertyWithTwoAnnotations_reportsAnnotations()
+    public final void annotations_methodsWithTwoAnnotations_reportsAnnotations()
             throws Exception {
         MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
 
@@ -43,7 +43,7 @@ public class MethodMetaPropertyTest extends
     }
 
     @Test
-    public final void annotationsFilter_propertyWithTwoAnnotations_reportsAnnotation()
+    public final void annotationsFilter_methodsWithTwoAnnotations_reportsAnnotation()
             throws Exception {
         MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
 

--- a/src/test/java/org/joda/pa/MethodMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/MethodMetaPropertyTest.java
@@ -4,9 +4,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.stream.Stream;
 
 import org.joda.pa.TestBean.GetAnnotation;
 import org.joda.pa.TestBean.SetAnnotation;
@@ -24,22 +22,23 @@ public class MethodMetaPropertyTest extends
             throws Exception {
         MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
 
-        Stream<Annotation> annotations = annotatedMetaProperty.annotations();
-
-        // report exactly two annotations
-        assertEquals(annotations.count(), 2);
+        // report exactly two annotation
+        long annotationsCount = annotatedMetaProperty
+                .annotations()
+                .count();
+        assertEquals(annotationsCount, 2);
 
         // report annotations of the correct type
-        long annotationsOnGet = annotatedMetaProperty
+        long annotationsCountOnGet = annotatedMetaProperty
                 .annotations()
                 .filter(GetAnnotation.class::isInstance)
                 .count();
-        assertEquals(annotationsOnGet, 1);
-        long annotationsOnSet = annotatedMetaProperty
+        assertEquals(annotationsCountOnGet, 1);
+        long annotationsCountOnSet = annotatedMetaProperty
                 .annotations()
                 .filter(SetAnnotation.class::isInstance)
                 .count();
-        assertEquals(annotationsOnSet, 1);
+        assertEquals(annotationsCountOnSet, 1);
     }
 
     @Test
@@ -48,14 +47,16 @@ public class MethodMetaPropertyTest extends
         MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
 
         // report exactly one annotation on get
-        Stream<? extends Annotation> annotationsOnGet =
-                annotatedMetaProperty.annotations(GetAnnotation.class);
-        assertEquals(annotationsOnGet.count(), 1);
+        long annotationsCountOnGet = annotatedMetaProperty
+                .annotations(GetAnnotation.class)
+                .count();
+        assertEquals(annotationsCountOnGet, 1);
 
         // report exactly one annotation on set
-        Stream<? extends Annotation> annotationsOnSet =
-                annotatedMetaProperty.annotations(SetAnnotation.class);
-        assertEquals(annotationsOnSet.count(), 1);
+        long annotationsCountOnSet = annotatedMetaProperty
+                .annotations(SetAnnotation.class)
+                .count();
+        assertEquals(annotationsCountOnSet, 1);
     }
 
     // implementation of 'AbstractFieldNameBasedMetaPropertyTest' -------------

--- a/src/test/java/org/joda/pa/MethodMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/MethodMetaPropertyTest.java
@@ -2,14 +2,47 @@ package org.joda.pa;
 
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.util.stream.Stream;
+
+import org.joda.pa.TestBean.GetAnnotation;
+import org.joda.pa.TestBean.SetAnnotation;
+import org.testng.annotations.Test;
 
 /**
  * Tests the class {@link FieldMetaProperty}.
  */
+@SuppressWarnings("javadoc")
 public class MethodMetaPropertyTest extends
         AbstractFieldNameBasedMetaPropertyTest {
+
+    @Test
+    public final void annotations_propertyWithTwoAnnotations_reportsAnnotations()
+            throws Exception {
+        MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
+
+        Stream<Annotation> annotations = annotatedMetaProperty.annotations();
+
+        // report exactly two annotations
+        assertEquals(annotations.count(), 2);
+
+        // report annotations of the correct type
+        long annotationsOnGet = annotatedMetaProperty
+                .annotations()
+                .filter(GetAnnotation.class::isInstance)
+                .count();
+        assertEquals(annotationsOnGet, 1);
+        long annotationsOnSet = annotatedMetaProperty
+                .annotations()
+                .filter(SetAnnotation.class::isInstance)
+                .count();
+        assertEquals(annotationsOnSet, 1);
+    }
+
+    // implementation of 'AbstractFieldNameBasedMetaPropertyTest' -------------
 
     @Override
     protected <P> MetaProperty<P> createMetaProperty(

--- a/src/test/java/org/joda/pa/MethodMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/MethodMetaPropertyTest.java
@@ -1,0 +1,65 @@
+package org.joda.pa;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Method;
+
+/**
+ * Tests the class {@link FieldMetaProperty}.
+ */
+public class MethodMetaPropertyTest extends
+        AbstractFieldNameBasedMetaPropertyTest {
+
+    @Override
+    protected <P> MetaProperty<P> createMetaProperty(
+            MetaBean metaBean, String name, Class<P> typeToken,
+            boolean derived, boolean buildable,
+            boolean readable, boolean mutable,
+            String fieldName)
+            throws Exception {
+
+        MetaBean notNullMetaBean = metaBean;
+        if (notNullMetaBean == null) {
+            notNullMetaBean = mock(MetaBean.class);
+            doReturn(TestBean.class).when(notNullMetaBean).beanType();
+        }
+
+        Method getValue = createGetMethod(readable, fieldName);
+        Method setValue = createSetMethod(mutable, fieldName, typeToken);
+
+        return new MethodMetaProperty<>(
+                notNullMetaBean, name, typeToken,
+                derived, buildable,
+                getValue, setValue);
+    }
+
+    private static Method createGetMethod(boolean readable, String fieldName)
+            throws NoSuchMethodException {
+        if (!readable) {
+            return null;
+        }
+
+        String getValueName = createMethodName("get", fieldName);
+        return FieldBackedTestBean.class.getMethod(getValueName);
+    }
+
+    private static <T> Method createSetMethod(
+            boolean mutable, String fieldName, Class<T> valueClass)
+            throws NoSuchMethodException {
+
+        if (!mutable) {
+            return null;
+        }
+
+        String setValueName = createMethodName("set", fieldName);
+        return FieldBackedTestBean.class.getMethod(setValueName, valueClass);
+    }
+
+    private static String createMethodName(String prefix, String fieldName) {
+        return prefix
+                + fieldName.substring(0, 1).toUpperCase()
+                + fieldName.substring(1);
+    }
+
+}

--- a/src/test/java/org/joda/pa/MethodMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/MethodMetaPropertyTest.java
@@ -42,6 +42,22 @@ public class MethodMetaPropertyTest extends
         assertEquals(annotationsOnSet, 1);
     }
 
+    @Test
+    public final void annotationsFilter_propertyWithTwoAnnotations_reportsAnnotation()
+            throws Exception {
+        MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
+
+        // report exactly one annotation on get
+        Stream<? extends Annotation> annotationsOnGet =
+                annotatedMetaProperty.annotations(GetAnnotation.class);
+        assertEquals(annotationsOnGet.count(), 1);
+
+        // report exactly one annotation on set
+        Stream<? extends Annotation> annotationsOnSet =
+                annotatedMetaProperty.annotations(SetAnnotation.class);
+        assertEquals(annotationsOnSet.count(), 1);
+    }
+
     // implementation of 'AbstractFieldNameBasedMetaPropertyTest' -------------
 
     @Override

--- a/src/test/java/org/joda/pa/TestBean.java
+++ b/src/test/java/org/joda/pa/TestBean.java
@@ -1,0 +1,66 @@
+package org.joda.pa;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+interface TestBean {
+
+    Object getObject();
+
+    void setObject(Object object);
+
+    @AnyAnnotation
+    String getString();
+
+    @AnyAnnotation
+    void setString(String string);
+
+    int getPrimitiveInteger();
+
+    void setPrimitiveInteger(int primitiveInteger);
+
+    @GetAnnotation
+    Integer getInteger();
+
+    @SetAnnotation
+    void setInteger(Integer integer);
+
+    List<Double> getDoubleList();
+
+    void setDoubleList(List<Double> doubleList);
+
+    // annotations
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ ElementType.FIELD, ElementType.METHOD })
+    @Inherited
+    static @interface AnyAnnotation {
+        // no values needed
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.FIELD)
+    @Inherited
+    static @interface FieldAnnotation {
+        // no values needed
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @Inherited
+    static @interface GetAnnotation {
+        // no values needed
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @Inherited
+    static @interface SetAnnotation {
+        // no values needed
+    }
+
+}


### PR DESCRIPTION
:exclamation: *This pull request is incomplete*

## Functionality

It provides three implementations of `MetaProperty`:

* `FunctionalMetaProperty` which uses functional interfaces to access the value and annotations
* `FieldMetaProperty` which reflects on a field to access the value and annotations
* `MethodMetaProperty` which reflects on get and set methods to access the value and annotations

These classes have a common superclass `AbstractMetaProperty` which does all the wiring and only leaves the actual value and annotation access to its subclasses.

All classes are only package visible. I plan to create a public `MetaPropertyBuilder` which allows the transparent instantiation of one of the implementations. It will also check arguments for validity (e.g. not null), which is currently not being done.

If this approach is approved I will do it in a separate pull request.

## Tests

The pull request contains tests for the three classes. In order to make sure, that all implementations execute the exact same tests, there is an abstract superclass for tests. It only leaves the creation of instances and detailed annotation checking to its subclasses.

I included TestNG and Mockito in the pom.