### PR TITLE
A 'MetaBean' which is generic in the bean's type

### DIFF
--- a/src/main/java/org/joda/pa/AbstractMetaProperty.java
+++ b/src/main/java/org/joda/pa/AbstractMetaProperty.java
@@ -20,11 +20,12 @@ import java.util.Objects;
 /**
  * Abstract superclass to {@link MetaProperty} implementations.
  * 
+ * @param <B> the type associated with the meta-bean that defines this meta-property 
  * @param <P> the type of the property content
  */
-abstract class AbstractMetaProperty<P> implements MetaProperty<P> {
+abstract class AbstractMetaProperty<B, P> implements MetaProperty<B, P> {
 
-    private final MetaBean metaBean;
+    private final MetaBean<B> metaBean;
     private final String name;
     private final Class<P> propertyTypeToken;
     private final boolean derived;
@@ -37,7 +38,7 @@ abstract class AbstractMetaProperty<P> implements MetaProperty<P> {
      * It relies on the calling builder to do so.
      */
     protected AbstractMetaProperty(
-            MetaBean metaBean, String name, Class<P> propertyTypeToken,
+            MetaBean<B> metaBean, String name, Class<P> propertyTypeToken,
             boolean derived, boolean buildable,
             boolean readable, boolean mutable) {
 
@@ -52,7 +53,7 @@ abstract class AbstractMetaProperty<P> implements MetaProperty<P> {
 
     //-----------------------------------------------------------------------
     @Override
-    public final MetaBean metaBean() {
+    public final MetaBean<B> metaBean() {
         return metaBean;
     }
 

--- a/src/main/java/org/joda/pa/Bean.java
+++ b/src/main/java/org/joda/pa/Bean.java
@@ -26,8 +26,10 @@ package org.joda.pa;
  * It is not a requirement that all beans implement this interface.
  * If a type does not implement the interface then reflection will be used to examine
  * getters and setters as per the original Java Bean specification.
+ * 
+ * @param <B> the type of the bean
  */
-public interface Bean {
+public interface Bean<B> {
 
     /**
      * Gets the meta-bean representing the parts of the bean that are
@@ -37,6 +39,6 @@ public interface Bean {
      * 
      * @return the meta-bean, not null
      */
-    MetaBean metaBean();
+    MetaBean<B> metaBean();
 
 }

--- a/src/main/java/org/joda/pa/BeanBuilder.java
+++ b/src/main/java/org/joda/pa/BeanBuilder.java
@@ -27,9 +27,9 @@ import java.util.Map;
  * <p>
  * A {@code BeanBuilder} is obtained from a {@link MetaBean}.
  * 
- * @param <T>  the type of the bean to be created
+ * @param <B>  the type of the bean to be created
  */
-public interface BeanBuilder<T> {
+public interface BeanBuilder<B> {
 
     /**
      * Gets the value of a single property previously added to the builder.
@@ -40,7 +40,7 @@ public interface BeanBuilder<T> {
      * @return the previously set value, null if none
      * @throws RuntimeException if the property or builder is invalid
      */
-    Object get(MetaProperty<?> property);
+    Object get(MetaProperty<?, ?> property);
 
     /**
      * Sets the value of a single property into the builder.
@@ -54,7 +54,7 @@ public interface BeanBuilder<T> {
      * @throws UnsupportedOperationException if the property is not {@link MetaProperty#isBuildable() buildable}
      * @throws RuntimeException if the property or builder is invalid
      */
-    BeanBuilder<T> set(MetaProperty<?> property, Object value);
+    BeanBuilder<B> set(MetaProperty<?, ?> property, Object value);
 
     /**
      * Builds the bean from the properties previously set into the builder.
@@ -65,6 +65,6 @@ public interface BeanBuilder<T> {
      * @return the created bean, not null
      * @throws RuntimeException if the builder is invalid
      */
-    T build();
+    B build();
 
 }

--- a/src/main/java/org/joda/pa/FieldMetaProperty.java
+++ b/src/main/java/org/joda/pa/FieldMetaProperty.java
@@ -23,9 +23,10 @@ import java.util.stream.Stream;
  * A {@link MetaProperty} which reflects on a {@link Field}
  * (provided during construction) to get/set values and access annotations.
  * 
+ * @param <B> the type associated with the meta-bean that defines this meta-property 
  * @param <P> the type of the property content
  */
-class FieldMetaProperty<P> extends AbstractMetaProperty<P> {
+class FieldMetaProperty<B, P> extends AbstractMetaProperty<B, P> {
 
     private final Field backingField;
 
@@ -34,7 +35,7 @@ class FieldMetaProperty<P> extends AbstractMetaProperty<P> {
      * It relies on the calling builder to do so.
      */
     FieldMetaProperty(
-            MetaBean metaBean, String name, Class<P> propertyTypeToken,
+            MetaBean<B> metaBean, String name, Class<P> propertyTypeToken,
             boolean derived, boolean buildable,
             boolean readable, boolean mutable,
             Field backingField) {

--- a/src/main/java/org/joda/pa/FunctionalMetaProperty.java
+++ b/src/main/java/org/joda/pa/FunctionalMetaProperty.java
@@ -25,9 +25,10 @@ import java.util.stream.Stream;
  * A {@link MetaProperty} which delegates calls to functional interfaces
  * (provided during construction) to get/set values and access annotations.
  * 
+ * @param <B> the type associated with the meta-bean that defines this meta-property 
  * @param <P> the type of the property content
  */
-class FunctionalMetaProperty<P> extends AbstractMetaProperty<P> {
+class FunctionalMetaProperty<B, P> extends AbstractMetaProperty<B, P> {
 
     private final Function<Object, P> getValue;
     private final BiConsumer<Object, P> setValue;
@@ -38,7 +39,7 @@ class FunctionalMetaProperty<P> extends AbstractMetaProperty<P> {
      * It relies on the calling builder to do so.
      */
     FunctionalMetaProperty(
-            MetaBean metaBean, String name, Class<P> propertyTypeToken,
+            MetaBean<B> metaBean, String name, Class<P> propertyTypeToken,
             boolean derived, boolean buildable,
             Function<Object, P> getValue, BiConsumer<Object, P> setValue,
             Supplier<Stream<Annotation>> getAnnotations) {

--- a/src/main/java/org/joda/pa/InheritingMetaProperty.java
+++ b/src/main/java/org/joda/pa/InheritingMetaProperty.java
@@ -1,0 +1,80 @@
+package org.joda.pa;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.stream.Stream;
+
+// TODO document
+class InheritingMetaProperty<B, P> implements MetaProperty<B, P> {
+
+    private final MetaProperty<? super B, P> inheritedProperty;
+    private final MetaBean<B> metaBean;
+
+    public InheritingMetaProperty(
+            MetaProperty<? super B, P> inheritedProperty, MetaBean<B> metaBean) {
+
+        this.inheritedProperty = inheritedProperty;
+        this.metaBean = metaBean;
+    }
+
+    @Override
+    public MetaBean<B> metaBean() {
+        return metaBean;
+    }
+
+    @Override
+    public String name() {
+        return inheritedProperty.name();
+    }
+
+    @Override
+    public Class<B> declaringType() {
+        return metaBean.beanType();
+    }
+
+    @Override
+    public Class<P> propertyType() {
+        return inheritedProperty.propertyType();
+    }
+
+    @Override
+    public Type propertyGenericType() {
+        return inheritedProperty.propertyGenericType();
+    }
+
+    @Override
+    public Stream<Annotation> annotations() {
+        return inheritedProperty.annotations();
+    }
+
+    @Override
+    public <A extends Annotation> Stream<A> annotations(Class<A> annotationType) {
+        return inheritedProperty.annotations(annotationType);
+    }
+
+    @Override
+    public boolean isDerived() {
+        return inheritedProperty.isDerived();
+    }
+
+    @Override
+    public boolean isBuildable() {
+        return inheritedProperty.isBuildable();
+    }
+
+    @Override
+    public boolean isMutable() {
+        return inheritedProperty.isMutable();
+    }
+
+    @Override
+    public P get(Object bean) {
+        return inheritedProperty.get(bean);
+    }
+
+    @Override
+    public void set(Object bean, Object value) {
+        inheritedProperty.set(bean, value);
+    }
+
+}

--- a/src/main/java/org/joda/pa/MetaBean.java
+++ b/src/main/java/org/joda/pa/MetaBean.java
@@ -36,8 +36,10 @@ import java.util.stream.Stream;
  * Implementations of this interface will typically represent the properties and annotations
  * of a fixed concrete class. However, implementations are permitted to be dynamic,
  * creating properties and/or annotations on demand.
+ * 
+ * @param <B> the type of the bean this meta-bean is associated with 
  */
-public interface MetaBean {
+public interface MetaBean<B> {
 
     /**
      * Obtains a meta-bean for a {@code Class}.
@@ -47,7 +49,7 @@ public interface MetaBean {
      * @param cls  the class whose associated {@code MetaBean} will be obtained
      * @return the meta-bean associated with the class, not null
      */
-    static MetaBean of(Class<?> cls) {
+    static <B> MetaBean<B> of(Class<B> cls) {
         return null;
     }
 
@@ -60,7 +62,7 @@ public interface MetaBean {
      * 
      * @return the type of the bean, not null
      */
-    Class<?> beanType();
+    Class<B> beanType();
 
     /**
      * Checks whether this bean is buildable or not.
@@ -87,7 +89,7 @@ public interface MetaBean {
      * @throws UnsupportedOperationException if the bean cannot be created
      * @see #isBuildable()
      */
-    BeanBuilder<?> beanBuilder();
+    BeanBuilder<B> beanBuilder();
 
     //-----------------------------------------------------------------------
     /**
@@ -103,7 +105,7 @@ public interface MetaBean {
      * 
      * @return the stream of properties on the bean, not null
      */
-    Stream<MetaProperty<?>> metaProperties();
+    Stream<MetaProperty<B, ?>> metaProperties();
 
     /**
      * Gets a single property by name.
@@ -123,7 +125,7 @@ public interface MetaBean {
      * @param propertyName the property name to retrieve, null returns an empty {@code Optional}
      * @return the property, or optional empty if no such property
      */
-    default Optional<MetaProperty<?>> metaProperty(String propertyName) {
+    default Optional<MetaProperty<B, ?>> metaProperty(String propertyName) {
         return metaProperties()
                 .filter(mp -> mp.name().equals(propertyName))
                 .findFirst();

--- a/src/main/java/org/joda/pa/MetaProperty.java
+++ b/src/main/java/org/joda/pa/MetaProperty.java
@@ -29,9 +29,10 @@ import java.util.stream.Stream;
  * <p>
  * A {@code MetaProperty} is obtained from a {@link MetaBean}.
  * 
- * @param <P>  the type of the property content
+ * @param <B> the type associated with the meta-bean that defines this meta-property 
+ * @param <P> the type of the property content
  */
-public interface MetaProperty<P> {
+public interface MetaProperty<B, P> {
 
     /**
      * Gets the meta-bean that defines this meta-property.
@@ -40,7 +41,7 @@ public interface MetaProperty<P> {
      * 
      * @return the meta-bean, not null
      */
-    MetaBean metaBean();
+    MetaBean<B> metaBean();
 
     /**
      * Gets the property name.
@@ -66,7 +67,7 @@ public interface MetaProperty<P> {
      * 
      * @return the type declaring the property, not null
      */
-    default Class<?> declaringType() {
+    default Class<B> declaringType() {
         return metaBean().beanType();
     }
 

--- a/src/main/java/org/joda/pa/MetaProperty.java
+++ b/src/main/java/org/joda/pa/MetaProperty.java
@@ -181,6 +181,11 @@ public interface MetaProperty<B, P> {
      * <p>
      * For a standard Java Bean, this is equivalent to calling {@code getFoo()} on the bean.
      * Alternate implementations may perform any logic to obtain the value.
+     * <p>
+     * The argument {@code bean} is not generic (in {@code B}) because this would prevent
+     * calling {@code get} on {@code MetaProperty<?, ?>}.
+     * Since meta-properties will often be handled by frameworks, this is a common use-case
+     * which needs to be supported.
      * 
      * @param bean  the bean to query, not null
      * @return the value of the property on the specified bean, may be null
@@ -196,8 +201,8 @@ public interface MetaProperty<B, P> {
      * For a standard Java Bean, this is equivalent to calling {@code setFoo()} on the bean.
      * Alternate implementations may perform any logic to change the value.
      * <p>
-     * The argument {@code value} is not generic (in {@code P}) because this would
-     * prevent calling {@code set} on {@code MetaProperty<?>}.
+     * The arguments {@code bean} and {@code value} are not generic (in {@code B} or {@code P})
+     * because this would prevent calling {@code set} on {@code MetaProperty<?, ?>}.
      * Since meta-properties will often be handled by frameworks, this is a common use-case
      * which needs to be supported.
      * 

--- a/src/main/java/org/joda/pa/MethodMetaProperty.java
+++ b/src/main/java/org/joda/pa/MethodMetaProperty.java
@@ -24,15 +24,16 @@ import java.util.stream.Stream;
  * A {@link MetaProperty} which reflects on {@link Method}s
  * (provided during construction) to get/set values and access annotations.
  * 
+ * @param <B> the type associated with the meta-bean that defines this meta-property 
  * @param <P> the type of the property content
  */
-class MethodMetaProperty<P> extends AbstractMetaProperty<P> {
+class MethodMetaProperty<B, P> extends AbstractMetaProperty<B, P> {
 
     private final Method getValue;
     private final Method setValue;
 
     protected MethodMetaProperty(
-            MetaBean metaBean, String name, Class<P> propertyTypeToken,
+            MetaBean<B> metaBean, String name, Class<P> propertyTypeToken,
             boolean derived, boolean buildable,
             Method getValue, Method setValue) {
 

--- a/src/test/java/org/joda/pa/AbstractFieldNameBasedMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractFieldNameBasedMetaPropertyTest.java
@@ -36,20 +36,20 @@ abstract class AbstractFieldNameBasedMetaPropertyTest extends
     }
 
     @Override
-    protected final MetaProperty<Object> createObjectMetaProperty()
+    protected final MetaProperty<?, Object> createObjectMetaProperty()
             throws Exception {
         return createMetaProperty(null, Object.class, "object");
     }
 
     @Override
-    protected final MetaProperty<Object> createObjectMetaPropertyWithMetaBean(
-            MetaBean metaBean)
+    protected final <B> MetaProperty<B, Object> createObjectMetaPropertyWithMetaBean(
+            MetaBean<B> metaBean)
             throws Exception {
         return createMetaProperty(metaBean, Object.class, "object");
     }
 
     @Override
-    protected final MetaProperty<Object> createObjectMetaPropertyWithName(
+    protected final MetaProperty<?, Object> createObjectMetaPropertyWithName(
             String name)
             throws Exception {
         return createMetaProperty(
@@ -58,7 +58,7 @@ abstract class AbstractFieldNameBasedMetaPropertyTest extends
     }
 
     @Override
-    protected final MetaProperty<Object> createReadOnlyObjectMetaProperty()
+    protected final MetaProperty<?, Object> createReadOnlyObjectMetaProperty()
             throws Exception {
         return createMetaProperty(
                 null, "object", Object.class,
@@ -66,7 +66,7 @@ abstract class AbstractFieldNameBasedMetaPropertyTest extends
     }
 
     @Override
-    protected final MetaProperty<Object> createWriteOnlyObjectMetaProperty()
+    protected final MetaProperty<?, Object> createWriteOnlyObjectMetaProperty()
             throws Exception {
         return createMetaProperty(
                 null, "object", Object.class,
@@ -74,7 +74,7 @@ abstract class AbstractFieldNameBasedMetaPropertyTest extends
     }
 
     @Override
-    protected final MetaProperty<Object> createDerivedObjectMetaProperty()
+    protected final MetaProperty<?, Object> createDerivedObjectMetaProperty()
             throws Exception {
         return createMetaProperty(
                 null, "object", Object.class,
@@ -82,7 +82,7 @@ abstract class AbstractFieldNameBasedMetaPropertyTest extends
     }
 
     @Override
-    protected final MetaProperty<Object> createNotBuildableObjectMetaProperty()
+    protected final MetaProperty<?, Object> createNotBuildableObjectMetaProperty()
             throws Exception {
         return createMetaProperty(
                 null, "object", Object.class,
@@ -90,33 +90,33 @@ abstract class AbstractFieldNameBasedMetaPropertyTest extends
     }
 
     @Override
-    protected final MetaProperty<String> createStringMetaProperty()
+    protected final MetaProperty<?, String> createStringMetaProperty()
             throws Exception {
         return createMetaProperty(null, String.class, "string");
     }
 
     @Override
-    protected final MetaProperty<Integer> createPrimitiveIntegerMetaProperty()
+    protected final MetaProperty<?, Integer> createPrimitiveIntegerMetaProperty()
             throws Exception {
         return createMetaProperty(null, int.class, "primitiveInteger");
     }
 
     @Override
-    protected final MetaProperty<Integer> createIntegerMetaProperty()
+    protected final MetaProperty<?, Integer> createIntegerMetaProperty()
             throws Exception {
         return createMetaProperty(null, Integer.class, "integer");
     }
 
     @Override
-    protected final MetaProperty<List<Double>> createDoubleListMetaProperty()
+    protected final MetaProperty<?, List<Double>> createDoubleListMetaProperty()
             throws Exception {
         @SuppressWarnings({ "unchecked", "rawtypes" })
         Class<List<Double>> typeToken = ((Class) List.class);
         return createMetaProperty(null, typeToken, "doubleList");
     }
 
-    private <P> MetaProperty<P> createMetaProperty(
-            MetaBean metaBean, Class<P> typeToken, String fieldName)
+    private <B, P> MetaProperty<B, P> createMetaProperty(
+            MetaBean<B> metaBean, Class<P> typeToken, String fieldName)
             throws Exception {
 
         return createMetaProperty(
@@ -124,8 +124,8 @@ abstract class AbstractFieldNameBasedMetaPropertyTest extends
                 fieldName);
     }
 
-    protected abstract <P> MetaProperty<P> createMetaProperty(
-            MetaBean metaBean, String name, Class<P> typeToken,
+    protected abstract <B, P> MetaProperty<B, P> createMetaProperty(
+            MetaBean<B> metaBean, String name, Class<P> typeToken,
             boolean derived, boolean buildable,
             boolean readable, boolean mutable,
             String fieldName)

--- a/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/AbstractMetaPropertyTest.java
@@ -45,15 +45,15 @@ public abstract class AbstractMetaPropertyTest {
     @Test
     public final void metaBean_compareWithConstructionArgument_same()
             throws Exception {
-        MetaBean metaBean = mock(MetaBean.class);
-        MetaProperty<?> metaProperty = createObjectMetaPropertyWithMetaBean(metaBean);
+        MetaBean<Object> metaBean = mock(MetaBean.class);
+        MetaProperty<?, ?> metaProperty = createObjectMetaPropertyWithMetaBean(metaBean);
         assertSame(metaProperty.metaBean(), metaBean);
     }
 
     @Test
     public final void declaringClass_compareWithBeanClass_same()
             throws Exception {
-        MetaProperty<?> metaProperty = createObjectMetaProperty();
+        MetaProperty<?, ?> metaProperty = createObjectMetaProperty();
         assertSame(metaProperty.declaringType(), TestBean.class);
     }
 
@@ -61,27 +61,27 @@ public abstract class AbstractMetaPropertyTest {
     public final void name_compareWithConstructionArgument_equals()
             throws Exception {
         String name = "thePropertyName";
-        MetaProperty<?> metaProperty = createObjectMetaPropertyWithName(name);
+        MetaProperty<?, ?> metaProperty = createObjectMetaPropertyWithName(name);
         assertEquals(metaProperty.name(), name);
     }
 
     @Test
     public final void propertyType_compareWithIntendedType_same()
             throws Exception {
-        MetaProperty<Object> objectMetaProperty = createObjectMetaProperty();
+        MetaProperty<?, Object> objectMetaProperty = createObjectMetaProperty();
         assertSame(objectMetaProperty.propertyType(), Object.class);
 
-        MetaProperty<String> stringMetaProperty = createStringMetaProperty();
+        MetaProperty<?, String> stringMetaProperty = createStringMetaProperty();
         assertSame(stringMetaProperty.propertyType(), String.class);
 
-        MetaProperty<Integer> primitiveIntegerMetaProperty =
+        MetaProperty<?, Integer> primitiveIntegerMetaProperty =
                 createPrimitiveIntegerMetaProperty();
         assertSame(primitiveIntegerMetaProperty.propertyType(), int.class);
 
-        MetaProperty<Integer> integerMetaProperty = createIntegerMetaProperty();
+        MetaProperty<?, Integer> integerMetaProperty = createIntegerMetaProperty();
         assertSame(integerMetaProperty.propertyType(), Integer.class);
 
-        MetaProperty<List<Double>> doubleListMetaProperty =
+        MetaProperty<?, List<Double>> doubleListMetaProperty =
                 createDoubleListMetaProperty();
         assertSame(doubleListMetaProperty.propertyType(), List.class);
     }
@@ -93,7 +93,7 @@ public abstract class AbstractMetaPropertyTest {
     @Test
     public final void annotations_propertyWithoutAnnotations_reportsNoAnnotations()
             throws Exception {
-        MetaProperty<?> notAnnotatedMetaProperty = createObjectMetaProperty();
+        MetaProperty<?, ?> notAnnotatedMetaProperty = createObjectMetaProperty();
         long annotationsCount = notAnnotatedMetaProperty
                 .annotations()
                 .count();
@@ -103,7 +103,7 @@ public abstract class AbstractMetaPropertyTest {
     @Test
     public final void annotations_propertyWithAnnotations_reportsAnnotations()
             throws Exception {
-        MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
+        MetaProperty<?, ?> annotatedMetaProperty = createStringMetaProperty();
 
         // reports at least one annotation
         long annotationsCount = annotatedMetaProperty
@@ -121,7 +121,7 @@ public abstract class AbstractMetaPropertyTest {
     @Test
     public final void annotationsFiltered_propertyWithoutAnnotations_reportsNoAnnotations()
             throws Exception {
-        MetaProperty<?> notAnnotatedMetaProperty = createObjectMetaProperty();
+        MetaProperty<?, ?> notAnnotatedMetaProperty = createObjectMetaProperty();
         long annotationsCount = notAnnotatedMetaProperty
                 .annotations()
                 .count();
@@ -131,7 +131,7 @@ public abstract class AbstractMetaPropertyTest {
     @Test
     public final void annotationsFiltered_propertyWithoutMatchingAnnotations_reportsNoAnnotations()
             throws Exception {
-        MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
+        MetaProperty<?, ?> annotatedMetaProperty = createStringMetaProperty();
         long notExistingAnnotationsCount = annotatedMetaProperty
                 .annotations(Retention.class)
                 .count();
@@ -141,7 +141,7 @@ public abstract class AbstractMetaPropertyTest {
     @Test
     public final void annotationsFiltered_propertyWithMatchingAnnotations_reportsAnnotations()
             throws Exception {
-        MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
+        MetaProperty<?, ?> annotatedMetaProperty = createStringMetaProperty();
 
         // reports at least one annotation
         long annotationsCount = annotatedMetaProperty
@@ -160,37 +160,37 @@ public abstract class AbstractMetaPropertyTest {
 
     @Test
     public final void isDerived_derivedProperty_true() throws Exception {
-        MetaProperty<?> metaProperty = createDerivedObjectMetaProperty();
+        MetaProperty<?, ?> metaProperty = createDerivedObjectMetaProperty();
         assertTrue(metaProperty.isDerived());
     }
 
     @Test
     public final void isDerived_notDerivedProperty_false() throws Exception {
-        MetaProperty<?> readOnlyMetaProperty = createObjectMetaProperty();
+        MetaProperty<?, ?> readOnlyMetaProperty = createObjectMetaProperty();
         assertFalse(readOnlyMetaProperty.isDerived());
     }
 
     @Test
     public final void isBuildable_buildableProperty_true() throws Exception {
-        MetaProperty<?> metaProperty = createObjectMetaProperty();
+        MetaProperty<?, ?> metaProperty = createObjectMetaProperty();
         assertTrue(metaProperty.isBuildable());
     }
 
     @Test
     public final void isBuildable_notBuildableProperty_false() throws Exception {
-        MetaProperty<?> readOnlyMetaProperty = createNotBuildableObjectMetaProperty();
+        MetaProperty<?, ?> readOnlyMetaProperty = createNotBuildableObjectMetaProperty();
         assertFalse(readOnlyMetaProperty.isBuildable());
     }
 
     @Test
     public final void isMutable_mutableProperty_true() throws Exception {
-        MetaProperty<?> metaProperty = createObjectMetaProperty();
+        MetaProperty<?, ?> metaProperty = createObjectMetaProperty();
         assertTrue(metaProperty.isMutable());
     }
 
     @Test
     public final void isMutable_readOnlyProperty_false() throws Exception {
-        MetaProperty<?> readOnlyMetaProperty = createReadOnlyObjectMetaProperty();
+        MetaProperty<?, ?> readOnlyMetaProperty = createReadOnlyObjectMetaProperty();
         assertFalse(readOnlyMetaProperty.isMutable());
     }
 
@@ -198,14 +198,14 @@ public abstract class AbstractMetaPropertyTest {
 
     @Test
     public final void get_valueNull_null() throws Exception {
-        MetaProperty<?> metaProperty = createObjectMetaProperty();
+        MetaProperty<?, ?> metaProperty = createObjectMetaProperty();
         TestBean bean = createBean();
         assertNull(metaProperty.get(bean));
     }
 
     @Test
     public final void get_existingValue_sameValue() throws Exception {
-        MetaProperty<String> stringMetaProperty = createStringMetaProperty();
+        MetaProperty<?, String> stringMetaProperty = createStringMetaProperty();
 
         TestBean bean = createBean();
         String value = "the not null value";
@@ -217,21 +217,21 @@ public abstract class AbstractMetaPropertyTest {
     @Test(expectedExceptions = ClassCastException.class)
     public final void get_incorrectBeanType_ClassCastException()
             throws Exception {
-        MetaProperty<?> metaProperty = createObjectMetaProperty();
+        MetaProperty<?, ?> metaProperty = createObjectMetaProperty();
         metaProperty.get("this is no bean");
     }
 
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public final void get_writeOnlyMetaProperty_UnsupportedOperationException()
             throws Exception {
-        MetaProperty<?> readOnlyMetaProperty = createWriteOnlyObjectMetaProperty();
+        MetaProperty<?, ?> readOnlyMetaProperty = createWriteOnlyObjectMetaProperty();
         TestBean bean = createBean();
         readOnlyMetaProperty.get(bean);
     }
 
     @Test
     public final void set_nullForObject_valueIsNull() throws Exception {
-        MetaProperty<Integer> integerMetaProperty = createIntegerMetaProperty();
+        MetaProperty<?, Integer> integerMetaProperty = createIntegerMetaProperty();
 
         TestBean bean = createBean();
         bean.setInteger(42);
@@ -243,7 +243,7 @@ public abstract class AbstractMetaPropertyTest {
 
     @Test
     public final void set_some_valueIsSame() throws Exception {
-        MetaProperty<List<Double>> doubleListMetaProperty =
+        MetaProperty<?, List<Double>> doubleListMetaProperty =
                 createDoubleListMetaProperty();
 
         TestBean bean = createBean();
@@ -257,21 +257,21 @@ public abstract class AbstractMetaPropertyTest {
     @Test(expectedExceptions = ClassCastException.class)
     public final void set_incorrectBeanType_ClassCastException()
             throws Exception {
-        MetaProperty<?> metaProperty = createObjectMetaProperty();
+        MetaProperty<?, ?> metaProperty = createObjectMetaProperty();
         metaProperty.set("this is no bean", null);
     }
 
     @Test(expectedExceptions = ClassCastException.class)
     public final void set_incorrectValueType_ClassCastException()
             throws Exception {
-        MetaProperty<Integer> integerMetaProperty = createIntegerMetaProperty();
+        MetaProperty<?, Integer> integerMetaProperty = createIntegerMetaProperty();
         TestBean bean = createBean();
         integerMetaProperty.set(bean, "this is no integer");
     }
 
     @Test(expectedExceptions = RuntimeException.class)
     public final void set_rejectedValue_RuntimeException() throws Exception {
-        MetaProperty<Integer> primitiveIntegerMetaProperty =
+        MetaProperty<?, Integer> primitiveIntegerMetaProperty =
                 createPrimitiveIntegerMetaProperty();
 
         TestBean bean = createBean();
@@ -283,7 +283,7 @@ public abstract class AbstractMetaPropertyTest {
     @Test(expectedExceptions = UnsupportedOperationException.class)
     public final void set_readOnlyMetaProperty_UnsupportedOperationException()
             throws Exception {
-        MetaProperty<?> readOnlyMetaProperty = createReadOnlyObjectMetaProperty();
+        MetaProperty<?, ?> readOnlyMetaProperty = createReadOnlyObjectMetaProperty();
         TestBean bean = createBean();
         readOnlyMetaProperty.set(bean, "some Value");
     }
@@ -292,9 +292,9 @@ public abstract class AbstractMetaPropertyTest {
 
     @Test
     public final void equals_otherBeanOtherName_false() throws Exception {
-        MetaProperty<?> objectMetaPropertyOnTestBean = createObjectMetaProperty();
-        MetaProperty<?> otherMetaPropertyOnSomeBean =
-                new ComparisonMetaProperty(
+        MetaProperty<?, ?> objectMetaPropertyOnTestBean = createObjectMetaProperty();
+        MetaProperty<?, ?> otherMetaPropertyOnSomeBean =
+                new ComparisonMetaProperty<>(
                         AbstractMetaPropertyTest.class, "somePropertyName");
 
         assertFalse(objectMetaPropertyOnTestBean
@@ -303,9 +303,9 @@ public abstract class AbstractMetaPropertyTest {
 
     @Test
     public final void equals_otherBeanSameName_false() throws Exception {
-        MetaProperty<?> objectMetaPropertyOnTestBean = createObjectMetaProperty();
-        MetaProperty<?> objectMetaPropertyOnSomeBean =
-                new ComparisonMetaProperty(
+        MetaProperty<?, ?> objectMetaPropertyOnTestBean = createObjectMetaProperty();
+        MetaProperty<?, ?> objectMetaPropertyOnSomeBean =
+                new ComparisonMetaProperty<>(
                         AbstractMetaPropertyTest.class, "object");
 
         assertFalse(objectMetaPropertyOnTestBean
@@ -314,9 +314,9 @@ public abstract class AbstractMetaPropertyTest {
 
     @Test
     public final void equals_sameBeanOtherName_false() throws Exception {
-        MetaProperty<?> objectMetaPropertyOnTestBean = createObjectMetaProperty();
-        MetaProperty<?> otherMetaPropertyOnTestBean =
-                new ComparisonMetaProperty(TestBean.class, "somePropertyName");
+        MetaProperty<?, ?> objectMetaPropertyOnTestBean = createObjectMetaProperty();
+        MetaProperty<?, ?> otherMetaPropertyOnTestBean =
+                new ComparisonMetaProperty<>(TestBean.class, "somePropertyName");
 
         assertFalse(objectMetaPropertyOnTestBean
                 .equals(otherMetaPropertyOnTestBean));
@@ -324,9 +324,9 @@ public abstract class AbstractMetaPropertyTest {
 
     @Test
     public final void equals_sameBeanSameName_true() throws Exception {
-        MetaProperty<?> objectMetaPropertyOnTestBean = createObjectMetaProperty();
-        MetaProperty<?> equalMetaProperty =
-                new ComparisonMetaProperty(TestBean.class, "object");
+        MetaProperty<?, ?> objectMetaPropertyOnTestBean = createObjectMetaProperty();
+        MetaProperty<?, ?> equalMetaProperty =
+                new ComparisonMetaProperty<>(TestBean.class, "object");
 
         assertTrue(objectMetaPropertyOnTestBean.equals(equalMetaProperty));
     }
@@ -357,57 +357,58 @@ public abstract class AbstractMetaPropertyTest {
      * Divergent behavior is specified by the factory method's name.
      */
 
-    protected abstract MetaProperty<Object> createObjectMetaProperty()
+    protected abstract MetaProperty<?, Object> createObjectMetaProperty()
             throws Exception;
 
-    protected abstract MetaProperty<Object> createObjectMetaPropertyWithMetaBean(
-            MetaBean metaBean)
+    protected abstract <B> MetaProperty<B, Object> createObjectMetaPropertyWithMetaBean(
+            MetaBean<B> metaBean)
             throws Exception;
 
-    protected abstract MetaProperty<Object> createObjectMetaPropertyWithName(
+    protected abstract MetaProperty<?, Object> createObjectMetaPropertyWithName(
             String name)
             throws Exception;
 
-    protected abstract MetaProperty<Object> createReadOnlyObjectMetaProperty()
+    protected abstract MetaProperty<?, Object> createReadOnlyObjectMetaProperty()
             throws Exception;
 
-    protected abstract MetaProperty<Object> createWriteOnlyObjectMetaProperty()
+    protected abstract MetaProperty<?, Object> createWriteOnlyObjectMetaProperty()
             throws Exception;
 
-    protected abstract MetaProperty<Object> createDerivedObjectMetaProperty()
+    protected abstract MetaProperty<?, Object> createDerivedObjectMetaProperty()
             throws Exception;
 
-    protected abstract MetaProperty<Object> createNotBuildableObjectMetaProperty()
+    protected abstract MetaProperty<?, Object> createNotBuildableObjectMetaProperty()
             throws Exception;
 
-    protected abstract MetaProperty<String> createStringMetaProperty()
+    protected abstract MetaProperty<?, String> createStringMetaProperty()
             throws Exception;
 
-    protected abstract MetaProperty<Integer> createPrimitiveIntegerMetaProperty()
+    protected abstract MetaProperty<?, Integer> createPrimitiveIntegerMetaProperty()
             throws Exception;
 
-    protected abstract MetaProperty<Integer> createIntegerMetaProperty()
+    protected abstract MetaProperty<?, Integer> createIntegerMetaProperty()
             throws Exception;
 
-    protected abstract MetaProperty<List<Double>> createDoubleListMetaProperty()
+    protected abstract MetaProperty<?, List<Double>> createDoubleListMetaProperty()
             throws Exception;
 
     /* 
      * inner classes ----------------------------------------------------------
      */
 
-    private static class ComparisonMetaProperty implements MetaProperty<Void> {
+    private static class ComparisonMetaProperty<B>
+            implements MetaProperty<B, Void> {
 
-        private final Class<?> declaringType;
+        private final Class<B> declaringType;
         private final String name;
 
-        public ComparisonMetaProperty(Class<?> declaringType, String name) {
+        public ComparisonMetaProperty(Class<B> declaringType, String name) {
             this.declaringType = declaringType;
             this.name = name;
         }
 
         @Override
-        public MetaBean metaBean() {
+        public MetaBean<B> metaBean() {
             throw new UnsupportedOperationException();
         }
 
@@ -422,7 +423,7 @@ public abstract class AbstractMetaPropertyTest {
         }
 
         @Override
-        public Class<?> declaringType() {
+        public Class<B> declaringType() {
             return declaringType;
         }
 

--- a/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FieldMetaPropertyTest.java
@@ -35,7 +35,7 @@ public class FieldMetaPropertyTest extends
     @Test
     public final void annotations_fieldWithAnnotation_reportsAnnotation()
             throws Exception {
-        MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
+        MetaProperty<?, ?> annotatedMetaProperty = createIntegerMetaProperty();
 
         // report exactly one annotation
         long annotationsCount = annotatedMetaProperty
@@ -53,7 +53,7 @@ public class FieldMetaPropertyTest extends
     @Test
     public final void annotationsFiltered_fieldWithAnnotation_reportsAnnotation()
             throws Exception {
-        MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
+        MetaProperty<?, ?> annotatedMetaProperty = createIntegerMetaProperty();
 
         // report exactly one annotation
         long annotationsCount = annotatedMetaProperty
@@ -65,14 +65,14 @@ public class FieldMetaPropertyTest extends
     // implementation of 'AbstractFieldNameBasedMetaPropertyTest' -------------
 
     @Override
-    protected <P> MetaProperty<P> createMetaProperty(
-            MetaBean metaBean, String name, Class<P> typeToken,
+    protected <B, P> MetaProperty<B, P> createMetaProperty(
+            MetaBean<B> metaBean, String name, Class<P> typeToken,
             boolean derived, boolean buildable,
             boolean readable, boolean mutable,
             String fieldName)
             throws Exception {
 
-        MetaBean notNullMetaBean = metaBean;
+        MetaBean<B> notNullMetaBean = metaBean;
         if (notNullMetaBean == null) {
             notNullMetaBean = mock(MetaBean.class);
             doReturn(TestBean.class).when(notNullMetaBean).beanType();

--- a/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/FunctionalMetaPropertyTest.java
@@ -44,7 +44,7 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
     @Test
     public final void annotations_fieldAndMethodWithSameAnnotations_reportsAnnotations()
             throws Exception {
-        MetaProperty<?> annotatedMetaProperty = createStringMetaProperty();
+        MetaProperty<?, ?> annotatedMetaProperty = createStringMetaProperty();
 
         // report exactly three annotation
         long annotationsCount = annotatedMetaProperty
@@ -62,7 +62,7 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
     @Test
     public final void annotations_fieldAndMethodWithDistinctAnnotations_reportsAnnotations()
             throws Exception {
-        MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
+        MetaProperty<?, ?> annotatedMetaProperty = createIntegerMetaProperty();
 
         // report all three annotations
         Stream<Annotation> annotations = annotatedMetaProperty.annotations();
@@ -89,7 +89,7 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
     @Test
     public final void annotationsFiltered_fieldAndMethodWithDistinctAnnotations_reportsAnnotation()
             throws Exception {
-        MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
+        MetaProperty<?, ?> annotatedMetaProperty = createIntegerMetaProperty();
 
         // report exactly one field annotation
         long annotationsCountOnField = annotatedMetaProperty
@@ -118,40 +118,41 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
     }
 
     @Override
-    protected MetaProperty<Object> createObjectMetaProperty() {
+    protected MetaProperty<?, Object> createObjectMetaProperty() {
         return createMetaProperty(
                 "object", Object.class,
                 TestBean::getObject, TestBean::setObject);
     }
 
     @Override
-    protected MetaProperty<Object> createObjectMetaPropertyWithMetaBean(
-            MetaBean metaBean) {
+    protected <B> MetaProperty<B, Object> createObjectMetaPropertyWithMetaBean(
+            MetaBean<B> metaBean) {
         return createMetaProperty(
                 metaBean, "object", Object.class,
                 TestBean::getObject, TestBean::setObject, null);
     }
 
     @Override
-    protected MetaProperty<Object> createObjectMetaPropertyWithName(String name) {
+    protected MetaProperty<?, Object> createObjectMetaPropertyWithName(
+            String name) {
         return createMetaProperty(
                 name, Object.class, TestBean::getObject, TestBean::setObject);
     }
 
     @Override
-    protected MetaProperty<Object> createReadOnlyObjectMetaProperty() {
+    protected MetaProperty<?, Object> createReadOnlyObjectMetaProperty() {
         return createMetaProperty(
                 "object", Object.class, TestBean::getObject, null);
     }
 
     @Override
-    protected MetaProperty<Object> createWriteOnlyObjectMetaProperty() {
+    protected MetaProperty<?, Object> createWriteOnlyObjectMetaProperty() {
         return createMetaProperty(
                 "object", Object.class, null, TestBean::setObject);
     }
 
     @Override
-    protected MetaProperty<Object> createDerivedObjectMetaProperty()
+    protected MetaProperty<?, Object> createDerivedObjectMetaProperty()
             throws Exception {
         return createMetaProperty(
                 null, "object", Object.class, true, true,
@@ -159,7 +160,7 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
     }
 
     @Override
-    protected MetaProperty<Object> createNotBuildableObjectMetaProperty()
+    protected MetaProperty<?, Object> createNotBuildableObjectMetaProperty()
             throws Exception {
         return createMetaProperty(
                 null, "object", Object.class, false, false,
@@ -167,7 +168,7 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
     }
 
     @Override
-    protected MetaProperty<String> createStringMetaProperty() {
+    protected MetaProperty<?, String> createStringMetaProperty() {
         Function<TestBean, String> getValue = TestBean::getString;
         BiConsumer<TestBean, String> setValue = TestBean::setString;
         Supplier<Stream<Annotation>> annotations =
@@ -215,7 +216,7 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
     }
 
     @Override
-    protected MetaProperty<Integer> createPrimitiveIntegerMetaProperty() {
+    protected MetaProperty<?, Integer> createPrimitiveIntegerMetaProperty() {
         Function<TestBean, Integer> getValue = TestBean::getPrimitiveInteger;
         BiConsumer<TestBean, Integer> setValue = TestBean::setPrimitiveInteger;
         return createMetaProperty(
@@ -224,7 +225,7 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
     }
 
     @Override
-    protected MetaProperty<Integer> createIntegerMetaProperty() {
+    protected MetaProperty<?, Integer> createIntegerMetaProperty() {
         Function<TestBean, Integer> getValue = TestBean::getInteger;
         BiConsumer<TestBean, Integer> setValue = TestBean::setInteger;
         Supplier<Stream<Annotation>> annotations =
@@ -235,7 +236,7 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
     }
 
     @Override
-    protected MetaProperty<List<Double>> createDoubleListMetaProperty() {
+    protected MetaProperty<?, List<Double>> createDoubleListMetaProperty() {
         Function<TestBean, List<Double>> getValue = TestBean::getDoubleList;
         BiConsumer<TestBean, List<Double>> setValue = TestBean::setDoubleList;
         @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -243,7 +244,7 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
         return createMetaProperty("doubleList", typeToken, getValue, setValue);
     }
 
-    private static <P> MetaProperty<P> createMetaProperty(
+    private static <P> MetaProperty<?, P> createMetaProperty(
             String name, Class<P> typeToken,
             Function<TestBean, P> getValue, BiConsumer<TestBean, P> setValue) {
 
@@ -251,8 +252,8 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
                 null, name, typeToken, getValue, setValue, null);
     }
 
-    private static <P> MetaProperty<P> createMetaProperty(
-            MetaBean metaBean, String name, Class<P> typeToken,
+    private static <B, P> MetaProperty<B, P> createMetaProperty(
+            MetaBean<B> metaBean, String name, Class<P> typeToken,
             Function<TestBean, P> getValue, BiConsumer<TestBean, P> setValue,
             Supplier<Stream<Annotation>> annotations) {
 
@@ -261,13 +262,13 @@ public class FunctionalMetaPropertyTest extends AbstractMetaPropertyTest {
                 getValue, setValue, annotations);
     }
 
-    private static <P> MetaProperty<P> createMetaProperty(
-            MetaBean metaBean, String name, Class<P> typeToken,
+    private static <B, P> MetaProperty<B, P> createMetaProperty(
+            MetaBean<B> metaBean, String name, Class<P> typeToken,
             boolean derived, boolean buildable,
             Function<TestBean, P> getValue, BiConsumer<TestBean, P> setValue,
             Supplier<Stream<Annotation>> annotations) {
 
-        MetaBean notNullMetaBean = metaBean;
+        MetaBean<B> notNullMetaBean = metaBean;
         if (notNullMetaBean == null) {
             notNullMetaBean = mock(MetaBean.class);
             doReturn(TestBean.class).when(notNullMetaBean).beanType();

--- a/src/test/java/org/joda/pa/MethodMetaPropertyTest.java
+++ b/src/test/java/org/joda/pa/MethodMetaPropertyTest.java
@@ -35,7 +35,7 @@ public class MethodMetaPropertyTest extends
     @Test
     public final void annotations_methodsWithTwoAnnotations_reportsAnnotations()
             throws Exception {
-        MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
+        MetaProperty<?, ?> annotatedMetaProperty = createIntegerMetaProperty();
 
         // report exactly two annotation
         long annotationsCount = annotatedMetaProperty
@@ -59,7 +59,7 @@ public class MethodMetaPropertyTest extends
     @Test
     public final void annotationsFilter_methodsWithTwoAnnotations_reportsAnnotation()
             throws Exception {
-        MetaProperty<?> annotatedMetaProperty = createIntegerMetaProperty();
+        MetaProperty<?, ?> annotatedMetaProperty = createIntegerMetaProperty();
 
         // report exactly one annotation on get
         long annotationsCountOnGet = annotatedMetaProperty
@@ -77,14 +77,14 @@ public class MethodMetaPropertyTest extends
     // implementation of 'AbstractFieldNameBasedMetaPropertyTest' -------------
 
     @Override
-    protected <P> MetaProperty<P> createMetaProperty(
-            MetaBean metaBean, String name, Class<P> typeToken,
+    protected <B, P> MetaProperty<B, P> createMetaProperty(
+            MetaBean<B> metaBean, String name, Class<P> typeToken,
             boolean derived, boolean buildable,
             boolean readable, boolean mutable,
             String fieldName)
             throws Exception {
 
-        MetaBean notNullMetaBean = metaBean;
+        MetaBean<B> notNullMetaBean = metaBean;
         if (notNullMetaBean == null) {
             notNullMetaBean = mock(MetaBean.class);
             doReturn(TestBean.class).when(notNullMetaBean).beanType();


### PR DESCRIPTION
:exclamation: **Experimental Branch**

Following the idea laid out in #6 this branch experiments with the possibility to make `MetaBean` generic in the bean's type `B`.

This entails the following type changes:
- `Bean` ~> `Bean<B>`
- `MetaBean` ~> `MetaBean<B>`
- `MetaProperty<P>` ~> `MetaPropert<B, P>`

As discussed before (see #6 for references), not all methods can be generified. The current state is very smooth, though. All return types are generic and concrete (i.e. not `?`) and so are most arguments. The (quite regular) exceptions are:
- `MetaProperty<B, P>`:
  - `get(Object)` could be `get(B)`
  - `set(Object, Object)` could be `set(B, P)`
- `BeanBuilder<B>`:
  - `get((MetaProperty<?, ?>)` could be `get((MetaProperty<B, ?>)`
  - `set((MetaProperty<?, ?>, Object)` could be `set((MetaProperty<B, ?>, P)`

The other changes to implementations and tests follow from this.
